### PR TITLE
docs: add Plausible analytics

### DIFF
--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -41,6 +41,9 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script defer data-domain="planr.so" src="https://analytics.int.macherjek.com/js/script.js" />
+      </head>
       <body className="flex min-h-screen flex-col">
         <RootProvider
           components={{ Link: NoPrefetchLink }}

--- a/apps/docs/scripts/verify-maintenance.mjs
+++ b/apps/docs/scripts/verify-maintenance.mjs
@@ -192,6 +192,14 @@ for (const redirect of legacyRedirects) {
 const nextConfig = await read('apps/docs/next.config.mjs');
 requireMarkers(nextConfig, 'Next.js static export wiring', ["output: 'export'", 'createMDX()', 'withMDX(config)']);
 
+const rootLayout = await read('apps/docs/app/layout.tsx');
+const plausibleScript = '<script defer data-domain="planr.so" src="https://analytics.int.macherjek.com/js/script.js" />';
+assert(rootLayout.includes(plausibleScript), 'root layout must include the exact deferred Plausible script');
+assert(
+  (rootLayout.match(/https:\/\/analytics\.int\.macherjek\.com\/js\/script\.js/g) ?? []).length === 1,
+  'root layout must include the Plausible script URL exactly once',
+);
+
 const alchemyConfig = await read('apps/docs/alchemy.run.ts');
 requireMarkers(alchemyConfig, 'Alchemy deployment wiring', [
   'Alchemy.Stack(', 'Cloudflare.providers()', 'Cloudflare.state()',
@@ -242,3 +250,4 @@ console.log(`published_routes=${routeMap.size} coverage_targets=${coverageTarget
 console.log(`redirects=${legacyRedirects.length} redirect_destinations=${new Set(legacyRedirects.map(({ destination }) => destination)).size}`);
 console.log(`exact_dependencies=${Object.keys(packageJson.dependencies).length + Object.keys(packageJson.devDependencies).length}`);
 console.log(`source_contracts=${sourceChecks.length}`);
+console.log('plausible_script_contract=passed');

--- a/apps/docs/scripts/verify-shell.mjs
+++ b/apps/docs/scripts/verify-shell.mjs
@@ -242,6 +242,7 @@ try {
   const home = await navigate('/');
   assert(home.h1?.includes('Give every agent a plan.'), 'Homepage hero heading is missing');
   const homeContract = await evaluate(`({
+    plausibleScripts: [...document.querySelectorAll('script[data-domain="planr.so"][src="https://analytics.int.macherjek.com/js/script.js"]')].map((script) => ({ defer: script.defer })),
     nav: [...document.querySelectorAll('header a')].map((link) => link.textContent.trim()),
     heroActions: [...document.querySelectorAll('.hero-actions a')].map((link) => ({ label: link.textContent.trim(), href: link.getAttribute('href') })),
     paths: [...document.querySelectorAll('.path-card')].length,
@@ -262,6 +263,7 @@ try {
     lifecycle: [...document.querySelectorAll('.lifecycle-preview li')].length,
     copyButton: document.querySelector('[data-testid="copy-command"]')?.getAttribute('aria-label')
   })`);
+  assert(JSON.stringify(homeContract.plausibleScripts) === JSON.stringify([{ defer: true }]), 'Homepage must render exactly one deferred Plausible script');
   assert(homeContract.nav.some((label) => label.includes('Docs')), 'Global Docs navigation is missing');
   assert(JSON.stringify(homeContract.heroActions) === JSON.stringify([
     { label: 'Set up with your agent', href: '#agent-setup' },


### PR DESCRIPTION
## Summary\n- add the supplied deferred Plausible tag globally to the docs root layout\n- protect the exact script/domain/uniqueness with source and browser-shell checks\n\n## Verification\n- pnpm docs:typecheck\n- pnpm docs:lint\n- pnpm docs:verify-maintenance\n- webpack static export + Cloudflare dry-run artifact verification\n- local browser shell: 68 pages, 20 interactions, 23 axe pages, 0 serious/critical