### PR TITLE
Fix generated docs references for Planr v1.5.2

### DIFF
--- a/apps/docs/content/docs/reference/cli-generated.mdx
+++ b/apps/docs/content/docs/reference/cli-generated.mdx
@@ -1,6 +1,6 @@
 ---
 title: Generated CLI Reference
-description: Complete compiled Planr 1.5.1 command and option help, checked against the repository binary.
+description: Complete compiled Planr 1.5.2 command and option help, checked against the repository binary.
 ---
 
 <Callout type="info" title="Generated executable contract">

--- a/apps/docs/content/docs/reference/mcp-schemas-generated.mdx
+++ b/apps/docs/content/docs/reference/mcp-schemas-generated.mdx
@@ -1,6 +1,6 @@
 ---
 title: Generated MCP Tool Schemas
-description: Complete Planr 1.5.1 tools/list inventory with every property, type, description, required field, enum/default declaration, and additionalProperties rule.
+description: Complete Planr 1.5.2 tools/list inventory with every property, type, description, required field, enum/default declaration, and additionalProperties rule.
 ---
 
 <Callout type="info" title="Generated runtime contract">


### PR DESCRIPTION
## Summary
- refresh generated CLI reference metadata for Planr 1.5.2
- refresh generated MCP schema reference metadata for Planr 1.5.2

## Why
Main CI run 29769901196 failed in Documentation at `Verify public reference coverage and drift` after the v1.5.2 release commit because the generated reference page descriptions still named Planr 1.5.1.

## Verification
- `pnpm docs:reference:generate`
- `pnpm docs:verify-reference` => passed with cli_reference_check=passed commands=110 version=1.5.2, mcp_schema_reference_check=passed tools=52 version=1.5.2, verify-reference ok=true assertions=237

## Release boundary
This PR does not move tag v1.5.2 and does not republish GitHub Release, npm, or Homebrew.