### PR TITLE
feat: add human map observation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.6.0] - 2026-07-21
+
+### Added
+
+- Added a human-only boxed graph observer with `planr map show --view diagram`. Its condensed nodes keep status, id, and title to at most two content lines, while `--full` restores complete node details.
+- Added `planr map watch` for live, change-driven graph supervision from a second terminal, with plan scoping, configurable polling, optional screen clearing, and `--until-settled` support.
+
+### Changed
+
+- Added an accessible terminal palette for map states and routes, with automatic TTY detection plus `--no-color` and `NO_COLOR` opt-outs.
+- Clarified dependency progress in human output: satisfied `blocks` edges render as `blocks✓` in the agent-adjacent tree and neutral `then` routes in the diagram, while unresolved dependencies remain red `blocks` routes.
+- Documented diagram and watch output as human supervision surfaces. Coding agents continue to use the compact default tree, `planr map show --json`, or the event-stream API.
+
+### Compatibility
+
+- Kept map status, link kinds, JSON output, readiness computation, and persistence unchanged; the new labels and colors are presentation-only.
+
 ## [1.5.2] - 2026-07-20
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -136,10 +136,23 @@ with log evidence, all reviews are closed complete, and a live verification log 
 the feature working in the browser. Iteration budget: 10.
 ```
 
-Mid-project work (a new feature, refactor, or fix on an existing project) works the same — it gets its own feature-scoped plan and extends the existing map. Both journeys with example prompts: [Two Journeys](docs/SKILLS.md#two-journeys-new-project-vs-existing-project). Watch progress anytime with `planr map show`.
+Mid-project work (a new feature, refactor, or fix on an existing project) works the same — it gets its own feature-scoped plan and extends the existing map. Both journeys with example prompts: [Two Journeys](docs/SKILLS.md#two-journeys-new-project-vs-existing-project). Coding agents inspect progress with the compact default `planr map show` or, preferably, `planr map show --json`. The tree preserves exact dependency vocabulary while marking satisfied edges as `blocks✓`; active `blocks` stay red. The boxed `planr map show --view diagram` renderer is exclusively for human supervision and uses neutral `then` routes once those dependencies are satisfied. Agents must not invoke it. Humans can add `--full` for complete status, title, worker, critical-lane, and pressure details. Interactive map output colors states automatically; `--no-color` and `NO_COLOR` keep it plain.
+
+To supervise an agent from a second terminal, leave the agent running in terminal A and watch its scoped graph in terminal B:
+
+```bash
+planr map watch --plan <plan-id>
+# optional: exit after every scoped item settles
+planr map watch --plan <plan-id> --until-settled
+# optional: inspect complete node details
+planr map watch --plan <plan-id> --full
+```
+
+The watcher is likewise a human-only observer. It defaults to the condensed diagram view, polls the local SQLite graph once per second, and redraws only when state changes. Coding agents must not invoke `map watch`; they should use `map show --json` snapshots or the `/v1/events/stream` SSE endpoint instead. Use Ctrl-C to stop.
 
 ## What's new
 
+- **1.6.0 — Human map observation:** Added a condensed boxed diagram, live two-terminal watching, accessible state colors, and clearer satisfied dependency routes. These views are intentionally for human supervision; agents keep using the default tree or JSON snapshots. See [Task Graph Model](docs/TASK_GRAPH_MODEL.md), [CLI Reference](docs/CLI_REFERENCE.md), and the [1.6.0 changelog](CHANGELOG.md#160---2026-07-21).
 - **1.5.2 — Standalone core, optional Switchloom:** Planr consumes provider-neutral repository declarations and route evidence only; it works without any routing files, and requested-only routing metadata is not execution proof. Optional model-routing lifecycle is external, with [Switchloom v0.2.1](https://github.com/instructa/switchloom/releases/tag/v0.2.1) verified as the repository-local handoff outside Planr. Start with [Model Routing](docs/MODEL_ROUTING.md), [Switchloom](https://switchloom.ai), the [Switchloom repository](https://github.com/instructa/switchloom), its tagged [setup quickstart](https://github.com/instructa/switchloom/blob/v0.2.1/README.md#setup-from-the-website) and [lifecycle docs](https://github.com/instructa/switchloom/blob/v0.2.1/docs/preset-composition.md#repository-lifecycle-commands), and the [Changelog](CHANGELOG.md).
 - **1.4.0 — Verified presets:** Added policy-driven composition, evaluation, signed registry evidence, and the public catalog. See the [1.4.0 release notes](https://github.com/instructa/planr/releases/tag/v1.4.0).
 - **1.3.0 — Native host hooks:** Added automatic session-state injection and loop recovery for supported hosts. See the [Hooks guide](docs/HOOKS.md) and [1.3.0 release notes](https://github.com/instructa/planr/releases/tag/v1.3.0).

--- a/apps/docs/content/docs/concepts/graph-and-readiness.mdx
+++ b/apps/docs/content/docs/concepts/graph-and-readiness.mdx
@@ -30,6 +30,27 @@ The direct lifecycle is `pending → ready → picked → closed`; `running` is 
 
 For readiness links, only an upstream `closed` or `closed_partial` status satisfies `blocks` and `hands_to`. A `cancelled` item counts as settled in aggregate progress, but it does **not** satisfy either readiness link; downstream remains pending until the graph is explicitly adapted. This prevents cancellation from silently authorizing dependent work.
 
+Coding agents use the compact default `planr map show` tree or, preferably, `planr map show --json`. They must not invoke the diagram renderer. When a person is supervising a branched workflow, the optional diagram view renders the same scoped map as boxes and labeled routes:
+
+```bash
+planr map show --view diagram
+planr map show --plan <plan-id> --view diagram
+planr map show --plan <plan-id> --view diagram --full
+```
+
+This is exclusively a human-supervision surface. Diagram nodes are condensed by default to at most two content lines in `ICON ITEM-ID → TITLE` form. An active dependency renders as red `blocks`; after its upstream reaches `closed` or `closed_partial`, the same stored edge renders as neutral `then`. Open, failed, and cancelled upstream items remain active `blocks`. The compact tree keeps the underlying kind explicit as `blocks✓` when satisfied, and structured output always remains `kind: "blocks"`. Humans can add `--full` when they need status words, complete wrapped titles, worker ownership, critical-lane markers, and downstream pressure. Shared joins, disconnected components, and cycle warnings remain visible in either detail mode. Interactive terminals color ready, active, review, closed, blocked, failed, pending, and cancelled states automatically. Use `--no-color` or `NO_COLOR` for plain output. The renderer does not create another graph representation: `tree` remains the default, SQLite remains authoritative, and JSON output is unchanged by diagram detail.
+
+For a person to observe agents from a second terminal, watch the whole map or one plan scope:
+
+```bash
+planr map watch
+planr map watch --plan <plan-id>
+planr map watch --plan <plan-id> --until-settled
+planr map watch --plan <plan-id> --full
+```
+
+Watch defaults to the condensed diagram view, polls once per second, and redraws only after graph state changes. `--full`, `--view tree`, `--interval-ms`, and `--no-clear` adjust the human presentation; Ctrl-C stops it. Watch is read-only and human-only. Coding agents must not invoke it; they use `planr map show --json` for structured snapshots or `planr serve` with `/v1/events/stream` for an event stream.
+
 ```bash
 planr map show --json
 planr map status --json

--- a/apps/docs/content/docs/reference/cli-generated.mdx
+++ b/apps/docs/content/docs/reference/cli-generated.mdx
@@ -433,7 +433,8 @@ Options:
 Usage: planr map [OPTIONS] [COMMAND]
 
 Commands:
-  show
+  show       Inspect map state. The diagram view is for humans; coding agents should use the default tree or JSON
+  watch      Human-only live observer. Coding agents should use `map show --json` or the event stream
   build
   lane
   pressure
@@ -455,6 +456,8 @@ Options:
 #### `planr map show`
 
 ```text
+Inspect map state. The diagram view is for humans; coding agents should use the default tree or JSON
+
 Usage: planr map show [OPTIONS]
 
 Options:
@@ -462,7 +465,29 @@ Options:
       --json
       --plan <PLAN>  Only show items and links belonging to this plan (plan id)
       --no-color     Disable color in human output
+      --view <VIEW>  Human output layout. `diagram` is for human supervision only; coding agents should use `tree` or `--json` [default: tree] [possible values: tree, diagram]
+      --full         Show the complete multi-line node details (diagram view only)
   -h, --help         Print help
+```
+
+#### `planr map watch`
+
+```text
+Human-only live observer. Coding agents should use `map show --json` or the event stream
+
+Usage: planr map watch [OPTIONS]
+
+Options:
+      --db <DB>                    Path to Planr SQLite database
+      --plan <PLAN>                Only watch items and links belonging to this plan (plan id)
+      --json                       Emit JSON output
+      --view <VIEW>                Human-only observation layout. Coding agents should use `map show --json` instead [default: diagram] [possible values: tree, diagram]
+      --full                       Show the complete multi-line node details (diagram view only)
+      --no-color                   Disable color in human output
+      --interval-ms <INTERVAL_MS>  Poll interval in milliseconds [default: 1000]
+      --no-clear                   Append changed frames instead of clearing an interactive terminal
+      --until-settled              Exit after rendering a fully settled scoped map
+  -h, --help                       Print help
 ```
 
 #### `planr map build`

--- a/apps/docs/content/docs/reference/cli.mdx
+++ b/apps/docs/content/docs/reference/cli.mdx
@@ -9,7 +9,7 @@ description: Invoke Planr reliably and navigate its complete generated command r
 planr [--db <path>] [--json] [--no-color] <command>
 ```
 
-`--db` selects an explicit SQLite database. Otherwise `PLANR_DB` wins, then Planr discovers `.planr/planr.sqlite` from the workspace. Use `--json` for scripts and agent calls; human output can change presentation without changing the JSON contract.
+`--db` selects an explicit SQLite database. Otherwise `PLANR_DB` wins, then Planr discovers `.planr/planr.sqlite` from the workspace. Use `--json` for scripts and agent calls; human output can change presentation without changing the JSON contract. In particular, `map show --view diagram` and `map watch` are exclusively human-supervision surfaces and coding agents must not invoke them. Agents use the default tree or `map show --json`. Interactive map output uses ANSI state colors automatically. `--no-color`, `NO_COLOR`, `TERM=dumb`, redirected output, and JSON keep it plain.
 
 ## Command families
 

--- a/docs/CLI_REFERENCE.md
+++ b/docs/CLI_REFERENCE.md
@@ -13,7 +13,8 @@ planr plan check <plan-id>
 planr plan audit <plan-id>
 planr plan show <plan-id>
 planr plan archive <plan-id>
-planr map show [--plan <plan-id>]
+planr map show [--plan <plan-id>] [--view tree|diagram] [--full]
+planr map watch [--plan <plan-id>] [--view tree|diagram] [--full] [--interval-ms 1000] [--no-clear] [--until-settled]
 planr map build --from <plan-id>
 planr map lane --critical
 planr map pressure
@@ -77,7 +78,7 @@ planr import <file> [--preview] [--confirm]
 planr export --out planr.json [--include-plans] [--include-logs] [--template-name "..."] [--tag tag]
 ```
 
-Global flags: `--db <path>`, `--json`, `--no-color`. They are valid in both positions: `planr --json pick` and `planr pick --json` behave identically.
+Global flags: `--db <path>`, `--json`, `--no-color`. They are valid in both positions: `planr --json pick` and `planr pick --json` behave identically. Human map output uses ANSI status colors only when stdout is an interactive terminal. `--no-color`, `NO_COLOR` (even when empty), `TERM=dumb`, redirected stdout, and JSON disable color; `PLANR_FORCE_COLOR=1` is available for compatible terminal wrappers and tests, but never overrides an explicit opt-out.
 
 ## JSON Envelope Convention
 
@@ -94,7 +95,11 @@ With `--json`, responses follow one convention so agents never guess where data 
 
 `plan audit <plan-id>` is the one-call contract verdict for a plan's map scope. JSON shape for machine consumers: top-level `holds` (bool) and `clauses[]` with `clause` (name) and `pass` (bool) — e.g. `planr plan audit <id> --json | jq '.holds, (.clauses[] | {clause, pass})'`. It evaluates four clauses with evidence: `items_settled` (open items listed), `reviews_complete` (open review items listed), `approvals_clear` (requested/denied approvals listed), and `verification_logged` (logs with `--kind verification` on scope items). The stored goal contract (`planr context --tag goal-contract` mentioning the plan id) is included; the verification clause is binding only when such a contract exists. `holds: true` means the contract is satisfied — loop agents use this as their stop condition instead of stitching the verdict together from `map status`, `log list`, and `approval list`. When the contract is open, `next` carries the exact next command derived from the first actionable gap: build the map, pick the ready review or work item (plan-scoped), resolve the blocking approval, inspect stalled leases, or log the missing verification. Also available as MCP `planr_plan_audit`.
 
-`map show --plan <plan-id>` narrows the map to one plan's items and the links among them, with plan-scoped counts — plan-scoped goal runs on shared boards audit their slice, not the whole board. An unknown plan id is an error, never a silent unscoped view. Also available on MCP `planr_map_show` (`plan`) and HTTP `GET /v1/projects/{id}/map?plan=<plan-id>`.
+`map show` defaults to the compact `tree` view used by agents and existing terminal workflows; coding agents should prefer `map show --json` when they need structured state. The tree keeps the canonical edge vocabulary visible: active dependencies render as red `blocks`, while an edge satisfied by a `closed` or `closed_partial` upstream renders as dim `blocks✓`. `map show --view diagram` is exclusively a human-supervision view and coding agents must not invoke it. It provides fixed-width boxes with at most two content lines in `ICON ITEM-ID → TITLE` form, translating satisfied `blocks` edges to neutral `then` while active or cancelled blockers remain `blocks`; `hands_to`, joins, disconnected components, and cycle warnings remain explicit. Humans can add `--full` for verbose nodes with status words, complete wrapped titles, active workers, critical-lane markers, and downstream pressure. `--full` is rejected with tree view. This is a read-only presentation over the same canonical map projection; JSON/MCP/HTTP always retain the stored `kind: "blocks"` and are identical across diagram detail choices.
+
+`map show --plan <plan-id>` narrows either human view to one plan's items and the links among them, with plan-scoped counts — plan-scoped goal runs on shared boards audit their slice, not the whole board. An unknown plan id is an error, never a silent unscoped view. Also available on MCP `planr_map_show` (`plan`) and HTTP `GET /v1/projects/{id}/map?plan=<plan-id>`.
+
+`map watch` is the read-only live companion for a second human terminal. Coding agents must not invoke it; they should use `map show --json` snapshots or `planr serve` plus `/v1/events/stream`. Watch defaults to the condensed `--view diagram`, polls every 1000 ms, compares the canonical scoped projection, and clears/redraws an interactive terminal only when graph state changes. `--full`, `--view tree`, `--plan <plan-id>`, `--interval-ms <n>` (minimum 100), `--no-clear`, and `--until-settled` control presentation and lifetime; Ctrl-C uses normal process interruption. JSON mode remains rejected because watch is intentionally human-only.
 
 `context list --tag <tag>` filters notes by the tag they were stored with (`context add --tag`), so e.g. the goal contract is recoverable with `planr context list --tag goal-contract` instead of scanning all notes.
 

--- a/docs/TASK_GRAPH_MODEL.md
+++ b/docs/TASK_GRAPH_MODEL.md
@@ -60,6 +60,12 @@ planr link add <design-item> <implementation-item> --type blocks
 
 Use `blocks` for hard ordering. Use softer link types only when the product contract for that type is documented and tested.
 
+Structured output always keeps that canonical `blocks` kind. Human rendering adds
+current satisfaction state without mutating it: an upstream `closed` or
+`closed_partial` item renders as dim `blocks✓` in the compact tree and neutral `then`
+in the human-only diagram. Open, failed, and cancelled upstream items still render as
+red `blocks`; cancellation does not satisfy readiness.
+
 ## Picking
 
 Picking is the concurrency boundary:
@@ -154,6 +160,50 @@ planr log add --item <item-id> --kind verification \
 Settling commands (`done`, `close`, `review close`) report what they `unlocked` — every item that became ready because of that settlement — plus the item's `post_condition` and an evidence hint when downstream work depends on an item closed without `--cmd`/`--tests`.
 
 ## Graph Inspection
+
+Coding agents use the compact default tree or `map show --json`. They must not
+invoke the diagram renderer. The boxed workflow diagram is exclusively for a
+person scanning the graph shape and current state:
+
+```bash
+planr map show
+planr map show --view diagram
+planr map show --plan <plan-id> --view diagram
+planr map show --plan <plan-id> --view diagram --full
+```
+
+The default diagram keeps every box to at most two content lines in
+`ICON ITEM-ID → TITLE` form. It still labels readiness-blocking routes, joins,
+disconnected components, and cycles. Active dependencies use `blocks`; satisfied
+dependencies use neutral `then`. Add `--full` for the previous verbose node
+layout with status words, complete wrapped titles, critical items, downstream
+pressure, and active workers. It is only a human renderer: coding agents do not
+invoke it, the SQLite map
+remains authoritative, the default `map show` view stays `tree`, and `--json`
+returns the same projection regardless of diagram detail.
+
+Human map states are colorized automatically on an interactive terminal while
+retaining their symbols and words. `--no-color`, `NO_COLOR`, `TERM=dumb`, pipes,
+and JSON stay plain.
+
+For a person to observe an agent live, use a second terminal:
+
+```bash
+# terminal A: agent/worker continues to pick, log, review, and close work
+# terminal B:
+planr map watch --plan <plan-id>
+planr map watch --plan <plan-id> --until-settled
+planr map watch --plan <plan-id> --full
+```
+
+`map watch` is human-only; coding agents must not invoke it. Watch defaults to
+the condensed diagram, polls once per second, and redraws only
+after a canonical graph change. `--full`, `--view tree`, `--interval-ms`, and
+`--no-clear` are available for detailed, compact-tree, or append-only
+observation. It records no graph events. Agents use `map show --json` or the
+local `/v1/events/stream` SSE endpoint instead.
+Machine consumers should use JSON snapshots or the local
+`/v1/events/stream` SSE endpoint.
 
 Use critical lane for ordering risk:
 

--- a/src/app/commands.rs
+++ b/src/app/commands.rs
@@ -228,8 +228,11 @@ impl App {
         match command.unwrap_or(MapCommand::Show(crate::cli::MapShowArgs {
             json: false,
             plan: None,
+            view: crate::cli::MapViewArg::Tree,
+            full: false,
         })) {
-            MapCommand::Show(args) => self.map_show(args.plan.as_deref()),
+            MapCommand::Show(args) => self.map_show(args.plan.as_deref(), args.view, args.full),
+            MapCommand::Watch(args) => self.map_watch(args),
             MapCommand::Build(args) => {
                 let plan = self.get_plan(&args.from)?;
                 let created = self.seed_items_from_plan(&plan)?;

--- a/src/app/http.rs
+++ b/src/app/http.rs
@@ -31,7 +31,7 @@ impl App {
             let json = self.json;
             std::thread::spawn(move || {
                 let app = match crate::storage::open_db(&db_path) {
-                    Ok(conn) => App::new(conn, root, db_path, json),
+                    Ok(conn) => App::new(conn, root, db_path, json, false),
                     Err(error) => {
                         eprintln!("planr serve: database open error: {error:#}");
                         return;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -36,15 +36,23 @@ pub(crate) struct App {
     pub(crate) root: PathBuf,
     pub(crate) db_path: PathBuf,
     pub(crate) json: bool,
+    pub(crate) color: bool,
 }
 
 impl App {
-    pub(crate) fn new(conn: Connection, root: PathBuf, db_path: PathBuf, json: bool) -> Self {
+    pub(crate) fn new(
+        conn: Connection,
+        root: PathBuf,
+        db_path: PathBuf,
+        json: bool,
+        color: bool,
+    ) -> Self {
         Self {
             conn,
             root,
             db_path,
             json,
+            color,
         }
     }
 }

--- a/src/app/render.rs
+++ b/src/app/render.rs
@@ -13,6 +13,102 @@ pub(crate) struct RenderEdge {
 }
 
 const OPEN_EXCLUDED: [&str; 3] = ["closed", "closed_partial", "cancelled"];
+const DIAGRAM_CONTENT_WIDTH: usize = 54;
+const ANSI_RESET: &str = "\x1b[0m";
+
+pub(crate) fn colorize_map(output: &str, enabled: bool) -> String {
+    if !enabled {
+        return output.to_string();
+    }
+
+    // Match once from left to right. Longer status phrases precede their bare
+    // icons so verbose nodes receive one ANSI span while condensed nodes can
+    // color the standalone icon without nesting escape sequences.
+    let tokens = [
+        ("◐ closed_partial", "32"),
+        ("◐ CLOSED_PARTIAL", "32"),
+        ("✓ closed", "32"),
+        ("✓ CLOSED", "32"),
+        ("✓ done", "32"),
+        ("○ ready", "36"),
+        ("○ READY", "36"),
+        ("◎ picked", "33"),
+        ("◎ PICKED", "33"),
+        ("◉ running", "1;33"),
+        ("◉ RUNNING", "1;33"),
+        ("◇ in_review", "35"),
+        ("◇ IN_REVIEW", "35"),
+        ("◇ review", "35"),
+        ("· pending", "2"),
+        ("· PENDING", "2"),
+        ("⊖ blocked", "31"),
+        ("⊖ BLOCKED", "31"),
+        ("✗ failed", "1;31"),
+        ("✗ FAILED", "1;31"),
+        ("⊘ cancelled", "2"),
+        ("⊘ CANCELLED", "2"),
+        ("blocks✓─▶", "2"),
+        ("then ─▶", "2"),
+        ("◐", "32"),
+        ("✓", "32"),
+        ("○", "36"),
+        ("◎", "33"),
+        ("◉", "1;33"),
+        ("◇", "35"),
+        ("·", "2"),
+        ("⊖", "31"),
+        ("✗", "1;31"),
+        ("⊘", "2"),
+        ("blocks─▶", "31"),
+        ("blocks ─▶", "31"),
+        ("hands_to─▶", "36"),
+        ("hands_to ─▶", "36"),
+        ("⏶", "33"),
+        ("★", "1;33"),
+        ("⚠ cycle:", "1;31"),
+        ("WORKFLOW MAP", "1;36"),
+    ];
+
+    let mut colored = String::with_capacity(output.len());
+    let mut remaining = output;
+    while !remaining.is_empty() {
+        let offset = output.len() - remaining.len();
+        if let Some((token, sgr)) = tokens.iter().find(|(token, _)| {
+            remaining.starts_with(token)
+                && (!is_bare_status_icon(token) || is_condensed_status_position(output, offset))
+        }) {
+            colored.push_str(&format!("\x1b[{sgr}m{token}{ANSI_RESET}"));
+            remaining = &remaining[token.len()..];
+            continue;
+        }
+
+        let character = remaining.chars().next().expect("remaining is not empty");
+        colored.push(character);
+        remaining = &remaining[character.len_utf8()..];
+    }
+    colored
+}
+
+fn is_bare_status_icon(token: &str) -> bool {
+    matches!(
+        token,
+        "◐" | "✓" | "○" | "◎" | "◉" | "◇" | "·" | "⊖" | "✗" | "⊘"
+    )
+}
+
+fn is_condensed_status_position(output: &str, offset: usize) -> bool {
+    let line_start = output[..offset].rfind('\n').map_or(0, |index| index + 1);
+    if output[line_start..offset].trim_start() != "│ " || line_start == 0 {
+        return false;
+    }
+
+    let previous_end = line_start - 1;
+    let previous_start = output[..previous_end]
+        .rfind('\n')
+        .map_or(0, |index| index + 1);
+    let previous = output[previous_start..previous_end].trim_start();
+    previous.starts_with('┌') && previous.ends_with('┐')
+}
 
 pub(crate) fn status_icon(status: &str) -> &'static str {
     match status {
@@ -50,6 +146,41 @@ pub(crate) fn render_map(
         out.push_str(&format!("\n⚠ cycle: {}", cycle.join(" → ")));
     }
     out
+}
+
+/// A deliberately human-first companion to the compact tree renderer.
+///
+/// The graph projection is identical to `render_map`; only presentation
+/// changes. Nodes stay in deterministic dependency-tree order, while boxes,
+/// route labels, and join references make the shape easier to supervise in a
+/// terminal without introducing a second graph/layout dependency.
+pub(crate) fn render_diagram_map(
+    project: &str,
+    items: &[Item],
+    edges: &[RenderEdge],
+    critical: &HashSet<String>,
+    cycles: &[Vec<String>],
+    full: bool,
+) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("── {project} · WORKFLOW MAP {}\n", "─".repeat(32)));
+    out.push_str(&state_line(project, items));
+    out.push_str("\n\n");
+    out.push_str("legend  ○ ready  · pending  ◎ picked  ◉ running  ◇ review  ✓ done\n");
+    out.push_str("        ⊖ blocked  ✗ failed  ⊘ cancelled\n");
+    out.push_str("        ★ critical  ⏶ downstream  blocks ─▶ active dependency\n");
+    out.push_str("        then ─▶ satisfied dependency  hands_to ─▶ handoff\n");
+    if items.is_empty() {
+        out.push_str("\n(no items)");
+        return out;
+    }
+
+    out.push('\n');
+    out.push_str(&render_diagram_tree(items, edges, critical, full));
+    for cycle in cycles {
+        out.push_str(&format!("\n⚠ cycle: {}", cycle.join(" → ")));
+    }
+    out.trim_end().to_string()
 }
 
 fn state_line(project: &str, items: &[Item]) -> String {
@@ -152,10 +283,329 @@ fn render_tree(items: &[Item], edges: &[RenderEdge], critical: &HashSet<String>)
     out
 }
 
+fn render_diagram_tree(
+    items: &[Item],
+    edges: &[RenderEdge],
+    critical: &HashSet<String>,
+    full: bool,
+) -> String {
+    let known = items
+        .iter()
+        .map(|item| item.id.as_str())
+        .collect::<HashSet<_>>();
+    let edges = edges
+        .iter()
+        .filter(|edge| known.contains(edge.from.as_str()) && known.contains(edge.to.as_str()))
+        .cloned()
+        .collect::<Vec<_>>();
+    let by_id = items
+        .iter()
+        .map(|item| (item.id.as_str(), item))
+        .collect::<HashMap<_, _>>();
+    let mut outgoing: BTreeMap<&str, Vec<&RenderEdge>> = BTreeMap::new();
+    let mut incoming: HashSet<&str> = HashSet::new();
+    let mut seen_edges = HashSet::new();
+    for edge in &edges {
+        if !seen_edges.insert((edge.from.as_str(), edge.to.as_str(), edge.kind.as_str())) {
+            continue;
+        }
+        outgoing.entry(edge.from.as_str()).or_default().push(edge);
+        incoming.insert(edge.to.as_str());
+    }
+    for children in outgoing.values_mut() {
+        children.sort_by(|a, b| a.to.cmp(&b.to).then_with(|| a.kind.cmp(&b.kind)));
+    }
+    let mut undirected: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for edge in &edges {
+        undirected
+            .entry(edge.from.as_str())
+            .or_default()
+            .push(edge.to.as_str());
+        undirected
+            .entry(edge.to.as_str())
+            .or_default()
+            .push(edge.from.as_str());
+    }
+
+    let pressure = pressure_counts(items, &edges);
+    let mut roots = items
+        .iter()
+        .filter(|item| !incoming.contains(item.id.as_str()))
+        .collect::<Vec<_>>();
+    roots.sort_by(|a, b| {
+        b.priority
+            .cmp(&a.priority)
+            .then_with(|| a.title.cmp(&b.title))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+
+    let mut out = String::new();
+    let mut printed = HashSet::new();
+    let mut assigned_to_component = HashSet::new();
+    let mut component = 0;
+    let seeds = roots
+        .iter()
+        .map(|item| item.id.as_str())
+        .chain(items.iter().map(|item| item.id.as_str()))
+        .collect::<Vec<_>>();
+    for seed in seeds {
+        if assigned_to_component.contains(seed) {
+            continue;
+        }
+        let mut component_ids = HashSet::new();
+        let mut stack = vec![seed];
+        while let Some(id) = stack.pop() {
+            if !component_ids.insert(id) {
+                continue;
+            }
+            assigned_to_component.insert(id);
+            if let Some(neighbors) = undirected.get(id) {
+                stack.extend(neighbors.iter().copied());
+            }
+        }
+
+        component += 1;
+        if component > 1 {
+            out.push('\n');
+        }
+        out.push_str(&format!("component {component}\n\n"));
+        let component_roots = roots
+            .iter()
+            .filter(|root| component_ids.contains(root.id.as_str()))
+            .collect::<Vec<_>>();
+        for (index, root) in component_roots.iter().enumerate() {
+            if index > 0 {
+                out.push('\n');
+            }
+            render_diagram_node(
+                &root.id,
+                None,
+                "",
+                true,
+                &by_id,
+                &outgoing,
+                critical,
+                &pressure,
+                &mut printed,
+                &mut out,
+                full,
+            );
+        }
+
+        // Rootless cycle components and any node not reachable following edge
+        // direction still need a deterministic entry point.
+        for item in items {
+            if !component_ids.contains(item.id.as_str()) || printed.contains(item.id.as_str()) {
+                continue;
+            }
+            if !component_roots.is_empty() || item.id.as_str() != seed {
+                out.push('\n');
+            }
+            render_diagram_node(
+                &item.id,
+                None,
+                "",
+                true,
+                &by_id,
+                &outgoing,
+                critical,
+                &pressure,
+                &mut printed,
+                &mut out,
+                full,
+            );
+        }
+    }
+    out
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_diagram_node(
+    id: &str,
+    incoming_edge: Option<&RenderEdge>,
+    prefix: &str,
+    is_last: bool,
+    by_id: &HashMap<&str, &Item>,
+    outgoing: &BTreeMap<&str, Vec<&RenderEdge>>,
+    critical: &HashSet<String>,
+    pressure: &HashMap<String, usize>,
+    printed: &mut HashSet<String>,
+    out: &mut String,
+    full: bool,
+) {
+    let Some(item) = by_id.get(id) else {
+        return;
+    };
+    let repeat = !printed.insert(id.to_string());
+    let node_prefix = if let Some(edge) = incoming_edge {
+        let connector = if is_last { "└─" } else { "├─" };
+        let label = edge_display_label(edge, by_id, EdgeSurface::Diagram);
+        out.push_str(&format!("{prefix}{connector} {label} ─▶\n"));
+        format!("{prefix}{}  ", if is_last { " " } else { "│" })
+    } else {
+        prefix.to_string()
+    };
+
+    for line in diagram_box_lines(item, critical.contains(id), pressure.get(id), repeat, full) {
+        out.push_str(&node_prefix);
+        out.push_str(&line);
+        out.push('\n');
+    }
+    if repeat {
+        return;
+    }
+
+    let children = outgoing.get(id).cloned().unwrap_or_default();
+    if children.is_empty() {
+        return;
+    }
+    out.push_str(&node_prefix);
+    out.push_str("│\n");
+    for (index, edge) in children.iter().enumerate() {
+        render_diagram_node(
+            &edge.to,
+            Some(edge),
+            &node_prefix,
+            index == children.len() - 1,
+            by_id,
+            outgoing,
+            critical,
+            pressure,
+            printed,
+            out,
+            full,
+        );
+    }
+}
+
+fn diagram_box_lines(
+    item: &Item,
+    is_critical: bool,
+    pressure: Option<&usize>,
+    repeat: bool,
+    full: bool,
+) -> Vec<String> {
+    let content = if full {
+        full_diagram_content(item, is_critical, pressure, repeat)
+    } else {
+        condensed_diagram_content(item, repeat)
+    };
+
+    let mut lines = vec![format!("┌{}┐", "─".repeat(DIAGRAM_CONTENT_WIDTH + 2))];
+    for line in content {
+        for wrapped in wrap_diagram_text(&line, DIAGRAM_CONTENT_WIDTH) {
+            lines.push(format!("│ {} │", pad_diagram_line(&wrapped)));
+        }
+    }
+    lines.push(format!("└{}┘", "─".repeat(DIAGRAM_CONTENT_WIDTH + 2)));
+    lines
+}
+
+fn full_diagram_content(
+    item: &Item,
+    is_critical: bool,
+    pressure: Option<&usize>,
+    repeat: bool,
+) -> Vec<String> {
+    let mut status = format!(
+        "{} {}",
+        status_icon(item.status.as_str()),
+        item.status.as_str().to_ascii_uppercase()
+    );
+    if is_critical {
+        status.push_str(" · ★ critical");
+    }
+    if let Some(count) = pressure.filter(|count| **count > 0) {
+        status.push_str(&format!(" · ⏶{count} downstream"));
+    }
+
+    let mut content = vec![status, item.id.clone()];
+    if repeat {
+        content.push("↳ joins a node already shown above".to_string());
+    } else {
+        content.extend(wrap_diagram_text(&item.title, DIAGRAM_CONTENT_WIDTH));
+        if let Some(worker) = &item.worker_id {
+            if matches!(item.status.as_str(), "picked" | "running") {
+                content.push(format!("worker: {worker}"));
+            }
+        }
+    }
+
+    content
+}
+
+fn condensed_diagram_content(item: &Item, repeat: bool) -> Vec<String> {
+    let repeat_marker = if repeat { " ↳ above" } else { "" };
+    let summary = format!(
+        "{} {} → {}{}",
+        status_icon(item.status.as_str()),
+        item.id,
+        item.title,
+        repeat_marker
+    );
+    wrap_diagram_text_limited(&summary, DIAGRAM_CONTENT_WIDTH, 2)
+}
+
+fn wrap_diagram_text(value: &str, width: usize) -> Vec<String> {
+    let mut lines = Vec::new();
+    let mut line = String::new();
+    for word in value.split_whitespace() {
+        if word.chars().count() > width {
+            if !line.is_empty() {
+                lines.push(std::mem::take(&mut line));
+            }
+            let chars = word.chars().collect::<Vec<_>>();
+            for chunk in chars.chunks(width) {
+                lines.push(chunk.iter().collect());
+            }
+            continue;
+        }
+        let separator = usize::from(!line.is_empty());
+        if line.chars().count() + separator + word.chars().count() > width {
+            lines.push(std::mem::take(&mut line));
+        }
+        if !line.is_empty() {
+            line.push(' ');
+        }
+        line.push_str(word);
+    }
+    if !line.is_empty() {
+        lines.push(line);
+    }
+    if lines.is_empty() {
+        lines.push(String::new());
+    }
+    lines
+}
+
+fn wrap_diagram_text_limited(value: &str, width: usize, max_lines: usize) -> Vec<String> {
+    let mut lines = wrap_diagram_text(value, width);
+    if lines.len() <= max_lines {
+        return lines;
+    }
+
+    lines.truncate(max_lines);
+    if let Some(last) = lines.last_mut() {
+        let keep = width.saturating_sub(1);
+        let mut truncated = last.chars().take(keep).collect::<String>();
+        truncated.push('…');
+        *last = truncated;
+    }
+    lines
+}
+
+fn pad_diagram_line(value: &str) -> String {
+    let length = value.chars().count();
+    format!(
+        "{value}{}",
+        " ".repeat(DIAGRAM_CONTENT_WIDTH.saturating_sub(length))
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_node(
     id: &str,
-    edge_kind: Option<&str>,
+    incoming_edge: Option<&RenderEdge>,
     prefix: &str,
     connector: &str,
     by_id: &HashMap<&str, &Item>,
@@ -170,8 +620,9 @@ fn render_node(
     };
     let repeat = !printed.insert(id.to_string());
     let mut line = format!("{prefix}{connector}");
-    if let Some(kind) = edge_kind {
-        line.push_str(&format!("{kind}─▶ "));
+    if let Some(edge) = incoming_edge {
+        let label = edge_display_label(edge, by_id, EdgeSurface::Tree);
+        line.push_str(&format!("{label}─▶ "));
     }
     line.push_str(&format!(
         "{} {} {} {}",
@@ -215,7 +666,7 @@ fn render_node(
         };
         render_node(
             &edge.to,
-            Some(&edge.kind),
+            Some(edge),
             &child_prefix,
             child_connector,
             by_id,
@@ -225,6 +676,31 @@ fn render_node(
             printed,
             out,
         );
+    }
+}
+
+#[derive(Clone, Copy)]
+enum EdgeSurface {
+    Tree,
+    Diagram,
+}
+
+fn edge_display_label<'a>(
+    edge: &'a RenderEdge,
+    by_id: &HashMap<&str, &Item>,
+    surface: EdgeSurface,
+) -> &'a str {
+    let satisfied = edge.kind == "blocks"
+        && by_id
+            .get(edge.from.as_str())
+            .is_some_and(|item| matches!(item.status.as_str(), "closed" | "closed_partial"));
+    if !satisfied {
+        return edge.kind.as_str();
+    }
+
+    match surface {
+        EdgeSurface::Tree => "blocks✓",
+        EdgeSurface::Diagram => "then",
     }
 }
 
@@ -375,6 +851,45 @@ mod tests {
         let edges = vec![edge("itm_a", "itm_b", "blocks")];
         let out = render_map("demo", &items, &edges, &HashSet::new(), &[]);
         assert!(!out.contains("itm_a Done ⏶"));
+        assert!(out.contains("blocks✓─▶"), "{out}");
+    }
+
+    #[test]
+    fn edge_labels_distinguish_satisfied_from_active_without_changing_kind() {
+        for (status, tree, diagram) in [
+            ("closed", "blocks✓", "then"),
+            ("closed_partial", "blocks✓", "then"),
+            ("ready", "blocks", "blocks"),
+            ("failed", "blocks", "blocks"),
+            ("cancelled", "blocks", "blocks"),
+        ] {
+            let source = item("source", "Source", status);
+            let by_id = [(source.id.as_str(), &source)].into_iter().collect();
+            let edge = edge("source", "target", "blocks");
+            assert_eq!(edge.kind, "blocks");
+            assert_eq!(
+                edge_display_label(&edge, &by_id, EdgeSurface::Tree),
+                tree,
+                "tree label for {status}"
+            );
+            assert_eq!(
+                edge_display_label(&edge, &by_id, EdgeSurface::Diagram),
+                diagram,
+                "diagram label for {status}"
+            );
+        }
+
+        let source = item("source", "Source", "closed");
+        let by_id = [(source.id.as_str(), &source)].into_iter().collect();
+        let handoff = edge("source", "target", "hands_to");
+        assert_eq!(
+            edge_display_label(&handoff, &by_id, EdgeSurface::Tree),
+            "hands_to"
+        );
+        assert_eq!(
+            edge_display_label(&handoff, &by_id, EdgeSurface::Diagram),
+            "hands_to"
+        );
     }
 
     #[test]
@@ -382,5 +897,161 @@ mod tests {
         let out = render_map("demo", &[], &[], &HashSet::new(), &[]);
         assert!(out.contains("(no items)"));
         assert!(out.contains("0/0 done (0%)"));
+    }
+
+    #[test]
+    fn diagram_groups_shared_roots_and_separates_truly_disconnected_nodes() {
+        let items = vec![
+            item("itm_a", "Root A", "ready"),
+            item("itm_b", "Root B", "ready"),
+            item("itm_join", "Shared join", "pending"),
+            item("itm_detached", "Detached", "ready"),
+        ];
+        let edges = vec![
+            edge("itm_a", "itm_join", "blocks"),
+            edge("itm_b", "itm_join", "hands_to"),
+        ];
+
+        let out = render_diagram_map("demo", &items, &edges, &HashSet::new(), &[], true);
+
+        assert_eq!(out.matches("component ").count(), 2, "{out}");
+        assert!(out.contains("blocks ─▶"), "{out}");
+        assert!(out.contains("hands_to ─▶"), "{out}");
+        assert!(out.contains("↳ joins a node already shown above"), "{out}");
+        assert!(out.contains("itm_detached"), "{out}");
+    }
+
+    #[test]
+    fn diagram_renders_linear_flow_with_operational_annotations() {
+        let mut root = item("itm_root", "Root work", "running");
+        root.worker_id = Some("worker-7".to_string());
+        let items = vec![root, item("itm_leaf", "Leaf work", "pending")];
+        let edges = vec![edge("itm_root", "itm_leaf", "blocks")];
+        let critical = ["itm_root".to_string(), "itm_leaf".to_string()]
+            .into_iter()
+            .collect::<HashSet<_>>();
+
+        let out = render_diagram_map("demo", &items, &edges, &critical, &[], true);
+
+        assert!(out.contains("── demo · WORKFLOW MAP"), "{out}");
+        assert!(
+            out.contains("◉ RUNNING · ★ critical · ⏶1 downstream"),
+            "{out}"
+        );
+        assert!(out.contains("worker: worker-7"), "{out}");
+        assert!(out.contains("└─ blocks ─▶"), "{out}");
+        assert!(out.contains("· PENDING · ★ critical"), "{out}");
+    }
+
+    #[test]
+    fn diagram_empty_map_keeps_summary_and_placeholder() {
+        let out = render_diagram_map("demo", &[], &[], &HashSet::new(), &[], false);
+
+        assert!(out.contains("demo: 0/0 done (0%)"), "{out}");
+        assert!(out.contains("(no items)"), "{out}");
+        assert!(!out.contains("component 1"), "{out}");
+    }
+
+    #[test]
+    fn diagram_cycle_terminates_and_reports_the_route() {
+        let items = vec![
+            item("itm_a", "One", "ready"),
+            item("itm_b", "Two", "pending"),
+        ];
+        let edges = vec![
+            edge("itm_a", "itm_b", "blocks"),
+            edge("itm_b", "itm_a", "blocks"),
+        ];
+        let cycles = vec![vec![
+            "itm_a".to_string(),
+            "itm_b".to_string(),
+            "itm_a".to_string(),
+        ]];
+
+        let out = render_diagram_map("demo", &items, &edges, &HashSet::new(), &cycles, true);
+
+        assert_eq!(out.matches("component ").count(), 1, "{out}");
+        assert_eq!(out.matches("│ itm_a").count(), 2, "{out}");
+        assert!(out.contains("↳ joins a node already shown above"), "{out}");
+        assert!(out.contains("⚠ cycle: itm_a → itm_b → itm_a"), "{out}");
+    }
+
+    #[test]
+    fn condensed_diagram_uses_icon_id_arrow_title_with_two_line_limit() {
+        let item = item(
+            "i-a-realistically-long-planr-item-id-1234",
+            "A deliberately long title that must wrap and then truncate before a third content line can make the graph too tall",
+            "closed",
+        );
+
+        let lines = diagram_box_lines(&item, true, Some(&9), false, false);
+        let content = &lines[1..lines.len() - 1];
+
+        assert_eq!(content.len(), 2, "{lines:#?}");
+        assert!(content[0].contains("✓ i-a-realistically-long-planr-item-id-1234 →"));
+        assert!(content[1].contains('…'), "{lines:#?}");
+        assert!(!lines.join("\n").contains("CLOSED"));
+        assert!(!lines.join("\n").contains("critical"));
+        assert!(!lines.join("\n").contains("downstream"));
+    }
+
+    #[test]
+    fn full_diagram_preserves_verbose_node_details() {
+        let mut item = item("itm_a", "Full title", "running");
+        item.worker_id = Some("worker-7".to_string());
+
+        let output = diagram_box_lines(&item, true, Some(&2), false, true).join("\n");
+
+        assert!(output.contains("◉ RUNNING · ★ critical · ⏶2 downstream"));
+        assert!(output.contains("worker: worker-7"));
+    }
+
+    #[test]
+    fn colorizes_condensed_icons_without_nesting_verbose_status_spans() {
+        let condensed = colorize_map(
+            "── demo · WORKFLOW MAP\n┌──┐\n│ ✓ itm_a → Done · title ◉ │\n└──┘\n   ┌──┐\n   │ · itm_b → Waiting ✓ │\n   └──┘\nlegend  ○ ready\n└─ blocks ─▶",
+            true,
+        );
+        assert!(condensed.contains("\x1b[32m✓\x1b[0m itm_a"));
+        assert!(condensed.contains("\x1b[2m·\x1b[0m itm_b"));
+        assert!(condensed.contains("demo · \x1b[1;36mWORKFLOW MAP\x1b[0m"));
+        assert!(condensed.contains("Done · title ◉"));
+        assert!(condensed.contains("Waiting ✓"));
+        assert!(condensed.contains("\x1b[36m○ ready\x1b[0m"));
+        assert!(condensed.contains("\x1b[31mblocks ─▶\x1b[0m"));
+
+        let edges = colorize_map("blocks─▶\nblocks✓─▶\nblocks ─▶\nthen ─▶", true);
+        assert_eq!(
+            edges,
+            "\x1b[31mblocks─▶\x1b[0m\n\x1b[2mblocks✓─▶\x1b[0m\n\x1b[31mblocks ─▶\x1b[0m\n\x1b[2mthen ─▶\x1b[0m"
+        );
+
+        let verbose = colorize_map("│ ✓ CLOSED · ★ critical · ⏶2 downstream │\n◉ RUNNING", true);
+        assert_eq!(
+            verbose,
+            "│ \x1b[32m✓ CLOSED\x1b[0m · \x1b[1;33m★\x1b[0m critical · \x1b[33m⏶\x1b[0m2 downstream │\n\x1b[1;33m◉ RUNNING\x1b[0m"
+        );
+
+        let full_title = item("itm_full", "✓ title glyph stays plain", "closed");
+        let full_box = colorize_map(
+            &diagram_box_lines(&full_title, false, None, false, true).join("\n"),
+            true,
+        );
+        assert!(
+            full_box.contains("│ ✓ title glyph stays plain"),
+            "{full_box:?}"
+        );
+
+        let long_id = "i".repeat(49);
+        let wrapped_title = item(&long_id, "✓ wrapped glyph stays plain", "pending");
+        let compact_box = colorize_map(
+            &diagram_box_lines(&wrapped_title, false, None, false, false).join("\n"),
+            true,
+        );
+        assert!(compact_box.contains("\x1b[2m·\x1b[0m"), "{compact_box:?}");
+        assert!(
+            compact_box.contains("│ ✓ wrapped glyph stays plain"),
+            "{compact_box:?}"
+        );
     }
 }

--- a/src/app/repository.rs
+++ b/src/app/repository.rs
@@ -7,6 +7,10 @@ use crate::util::{collect_rows, item_id, print_json, short_id, worker_id};
 use anyhow::{Result, bail};
 use rusqlite::{OptionalExtension, params};
 use serde_json::{Value, json};
+use std::env;
+use std::io::{IsTerminal, Write, stdout};
+use std::thread;
+use std::time::Duration;
 
 mod context;
 mod evidence;
@@ -423,11 +427,89 @@ impl App {
             .collect()
     }
 
-    pub(crate) fn map_show(&self, plan: Option<&str>) -> Result<()> {
+    pub(crate) fn map_show(
+        &self,
+        plan: Option<&str>,
+        view: crate::cli::MapViewArg,
+        full: bool,
+    ) -> Result<()> {
+        Self::validate_map_detail(view, full)?;
         let value = self.map_value(plan)?;
         if self.json {
             return self.emit(value, String::new());
         }
+        let human = self.render_map_human(&value, view, full)?;
+        self.emit(value, human)
+    }
+
+    pub(crate) fn map_watch(&self, args: crate::cli::MapWatchArgs) -> Result<()> {
+        Self::validate_map_detail(args.view, args.full)?;
+        if self.json {
+            bail!(
+                "refusing JSON map watch: use `planr map show --json` for snapshots or `planr serve` with `/v1/events/stream` for machine event streaming"
+            );
+        }
+
+        let clear_screen = !args.no_clear
+            && stdout().is_terminal()
+            && env::var("TERM").ok().as_deref() != Some("dumb");
+        let mut previous = None;
+        let mut polls = 0u64;
+        let mut frames = 0u64;
+        loop {
+            let value = self.map_value(args.plan.as_deref())?;
+            let key = serde_json::to_string(&value)?;
+            if previous.as_deref() != Some(key.as_str()) {
+                frames += 1;
+                let human = self.render_map_human(&value, args.view, args.full)?;
+                let view = match args.view {
+                    crate::cli::MapViewArg::Tree => "tree",
+                    crate::cli::MapViewArg::Diagram => "diagram",
+                };
+                let scope = args
+                    .plan
+                    .as_deref()
+                    .map(|plan| format!(" · plan {plan}"))
+                    .unwrap_or_default();
+                let mut output = stdout().lock();
+                if clear_screen {
+                    write!(output, "\x1b[2J\x1b[H")?;
+                }
+                writeln!(
+                    output,
+                    "watching map · {view}{scope} · every {}ms · update {frames} · Ctrl-C to stop",
+                    args.interval_ms
+                )?;
+                writeln!(output)?;
+                writeln!(output, "{human}")?;
+                output.flush()?;
+                previous = Some(key);
+            }
+
+            polls += 1;
+            let settled = value["settled"].as_u64() == value["total"].as_u64();
+            if (args.until_settled && settled)
+                || args.iterations.is_some_and(|limit| polls >= limit)
+            {
+                return Ok(());
+            }
+            thread::sleep(Duration::from_millis(args.interval_ms));
+        }
+    }
+
+    fn validate_map_detail(view: crate::cli::MapViewArg, full: bool) -> Result<()> {
+        if full && !matches!(view, crate::cli::MapViewArg::Diagram) {
+            bail!("`--full` requires `--view diagram`");
+        }
+        Ok(())
+    }
+
+    fn render_map_human(
+        &self,
+        value: &Value,
+        view: crate::cli::MapViewArg,
+        full: bool,
+    ) -> Result<String> {
         let project_name = self
             .default_project()
             .map(|project| project.name)
@@ -458,8 +540,21 @@ impl App {
             .map(|lane| lane.into_iter().map(|item| item.id).collect())
             .unwrap_or_default();
         let cycles = self.graph_cycles().unwrap_or_default();
-        let human = super::render::render_map(&project_name, &items, &edges, &critical, &cycles);
-        self.emit(value, human)
+        let human = match view {
+            crate::cli::MapViewArg::Tree => {
+                super::render::render_map(&project_name, &items, &edges, &critical, &cycles)
+            }
+            crate::cli::MapViewArg::Diagram => super::render::render_diagram_map(
+                &project_name,
+                &items,
+                &edges,
+                &critical,
+                &cycles,
+                full,
+            ),
+        };
+        let human = super::render::colorize_map(&human, self.color);
+        Ok(human)
     }
 
     /// `plan` narrows the map to one plan's items and the links among them —

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -237,11 +237,60 @@ pub(crate) struct MapShowArgs {
     /// Only show items and links belonging to this plan (plan id)
     #[arg(long)]
     pub(crate) plan: Option<String>,
+    /// Human output layout. `diagram` is for human supervision only; coding agents should use `tree` or `--json`.
+    #[arg(long, value_enum, default_value_t = MapViewArg::Tree)]
+    pub(crate) view: MapViewArg,
+    /// Show the complete multi-line node details (diagram view only).
+    #[arg(long)]
+    pub(crate) full: bool,
+}
+
+#[derive(Args, Debug)]
+pub(crate) struct MapWatchArgs {
+    /// Only watch items and links belonging to this plan (plan id)
+    #[arg(long)]
+    pub(crate) plan: Option<String>,
+    /// Human-only observation layout. Coding agents should use `map show --json` instead.
+    #[arg(long, value_enum, default_value_t = MapViewArg::Diagram)]
+    pub(crate) view: MapViewArg,
+    /// Show the complete multi-line node details (diagram view only).
+    #[arg(long)]
+    pub(crate) full: bool,
+    /// Poll interval in milliseconds.
+    #[arg(
+        long,
+        default_value_t = 1000,
+        value_parser = clap::value_parser!(u64).range(100..)
+    )]
+    pub(crate) interval_ms: u64,
+    /// Append changed frames instead of clearing an interactive terminal.
+    #[arg(long)]
+    pub(crate) no_clear: bool,
+    /// Exit after rendering a fully settled scoped map.
+    #[arg(long)]
+    pub(crate) until_settled: bool,
+    /// Bound polling for deterministic smoke tests.
+    #[arg(
+        long,
+        hide = true,
+        value_parser = clap::value_parser!(u64).range(1..)
+    )]
+    pub(crate) iterations: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Default, ValueEnum)]
+pub(crate) enum MapViewArg {
+    #[default]
+    Tree,
+    Diagram,
 }
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum MapCommand {
+    /// Inspect map state. The diagram view is for humans; coding agents should use the default tree or JSON.
     Show(MapShowArgs),
+    /// Human-only live observer. Coding agents should use `map show --json` or the event stream.
+    Watch(MapWatchArgs),
     Build(MapBuildArgs),
     Lane(MapLaneArgs),
     Pressure,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,7 @@ fn run() -> Result<()> {
     }
     let conn = open_db(&db_path)?;
     ensure_schema(&conn)?;
-    let app = App::new(conn, root, db_path, cli.json);
+    let color = util::color_enabled(cli.no_color, cli.json);
+    let app = App::new(conn, root, db_path, cli.json, color);
     app.dispatch(cli.command)
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,11 @@ use anyhow::{Result, anyhow};
 use rusqlite::Connection;
 use serde_json::{Value, json};
 use slug::slugify;
-use std::{env, fs, path::Path};
+use std::{
+    env, fs,
+    io::{IsTerminal, stdout},
+    path::Path,
+};
 use time::OffsetDateTime;
 use uuid::Uuid;
 
@@ -41,6 +45,37 @@ pub fn query_json(
 pub fn print_json(value: &Value) -> Result<()> {
     println!("{}", serde_json::to_string_pretty(value)?);
     Ok(())
+}
+
+/// Resolve the process-wide human-output color policy once at startup.
+/// Explicit opt-outs always beat the force flag; redirected output stays
+/// plain unless a terminal wrapper deliberately opts in.
+pub fn color_enabled(no_color: bool, json: bool) -> bool {
+    resolve_color(
+        no_color,
+        json,
+        env::var_os("NO_COLOR").is_some(),
+        env::var("TERM").ok().as_deref(),
+        env::var("PLANR_FORCE_COLOR").ok().as_deref(),
+        stdout().is_terminal(),
+    )
+}
+
+fn resolve_color(
+    no_color: bool,
+    json: bool,
+    no_color_env: bool,
+    term: Option<&str>,
+    force: Option<&str>,
+    stdout_is_terminal: bool,
+) -> bool {
+    if no_color || json || no_color_env || term == Some("dumb") {
+        return false;
+    }
+    if force.is_some_and(|value| !value.is_empty() && value != "0") {
+        return true;
+    }
+    stdout_is_terminal
 }
 
 /// The breakdown title contract: repeated `--into` flags each carry one
@@ -286,5 +321,70 @@ pub fn mime_for_path(path: &str) -> &'static str {
         Some("zip") => "application/zip",
         Some("txt") | Some("log") => "text/plain",
         _ => "application/octet-stream",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_color;
+
+    #[test]
+    fn color_policy_prioritizes_explicit_opt_outs() {
+        assert!(resolve_color(
+            false,
+            false,
+            false,
+            Some("xterm"),
+            None,
+            true
+        ));
+        assert!(resolve_color(
+            false,
+            false,
+            false,
+            Some("xterm"),
+            Some("1"),
+            false
+        ));
+        assert!(!resolve_color(
+            true,
+            false,
+            false,
+            Some("xterm"),
+            Some("1"),
+            true
+        ));
+        assert!(!resolve_color(
+            false,
+            true,
+            false,
+            Some("xterm"),
+            Some("1"),
+            true
+        ));
+        assert!(!resolve_color(
+            false,
+            false,
+            true,
+            Some("xterm"),
+            Some("1"),
+            true
+        ));
+        assert!(!resolve_color(
+            false,
+            false,
+            false,
+            Some("dumb"),
+            Some("1"),
+            true
+        ));
+        assert!(!resolve_color(
+            false,
+            false,
+            false,
+            Some("xterm"),
+            Some("0"),
+            false
+        ));
     }
 }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -3,11 +3,12 @@ use predicates::prelude::*;
 use rusqlite::Connection;
 use serde_json::{Value, json};
 use std::fs;
-use std::io::{Read, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::process::Command as StdCommand;
+use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tempfile::tempdir;
 
 fn planr() -> Command {
@@ -5454,6 +5455,25 @@ fn map_show_renders_visual_dag_tree_and_state_line() {
         .get_output()
         .stdout
         .clone();
+    let explicit_tree = planr()
+        .current_dir(dir.path())
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "map",
+            "show",
+            "--view",
+            "tree",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(
+        output, explicit_tree,
+        "the explicit tree view must be byte-identical to the default"
+    );
     let human = String::from_utf8(output).unwrap();
     assert!(
         human.contains("Graph View: 0/3 done (0%) | ready 1 | active 0 | in_review 0 | blocked 2"),
@@ -5487,6 +5507,520 @@ fn map_show_renders_visual_dag_tree_and_state_line() {
         value["counts"]["ready"], 1,
         "blocked downstream items must not count as ready"
     );
+}
+
+#[test]
+fn map_show_diagram_renders_shared_routes_and_preserves_json_contract() {
+    let dir = tempdir().unwrap();
+    let db = dir.path().join(".planr/planr.sqlite");
+    planr()
+        .current_dir(dir.path())
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "project",
+            "init",
+            "Diagram View",
+        ])
+        .assert()
+        .success();
+
+    let root_a = create_test_item(dir.path(), &db, "Root A", "root a");
+    let root_b = create_test_item(dir.path(), &db, "Root B", "root b");
+    let join = create_test_item_after(dir.path(), &db, "Shared join", "join", &root_a);
+    planr()
+        .current_dir(dir.path())
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "link",
+            "add",
+            &root_b,
+            &join,
+            "--type",
+            "hands_to",
+        ])
+        .assert()
+        .success();
+
+    let output = planr()
+        .current_dir(dir.path())
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "map",
+            "show",
+            "--view",
+            "diagram",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let human = String::from_utf8(output).unwrap();
+    assert!(human.contains("── Diagram View · WORKFLOW MAP"), "{human}");
+    assert_eq!(human.matches("component ").count(), 1, "{human}");
+    assert!(human.contains("┌────────────────"), "{human}");
+    assert!(human.contains("blocks ─▶"), "{human}");
+    assert!(human.contains("hands_to ─▶"), "{human}");
+    assert!(!human.contains("READY"), "{human}");
+    assert!(!human.contains("PENDING"), "{human}");
+    assert!(human.contains(&root_a), "{human}");
+    assert!(human.contains(&root_b), "{human}");
+    assert!(human.contains(&join), "{human}");
+    let mut content_rows = 0;
+    let mut boxes = 0;
+    for line in human.lines() {
+        if line.contains('┌') {
+            content_rows = 0;
+        } else if line.contains('└') && line.contains('┘') {
+            assert!(
+                (1..=2).contains(&content_rows),
+                "compact box contained {content_rows} content rows:\n{human}"
+            );
+            boxes += 1;
+        } else if line.contains('│') && line.ends_with('│') {
+            content_rows += 1;
+        }
+    }
+    assert!(boxes >= 3, "expected compact boxes in:\n{human}");
+
+    let full = planr()
+        .current_dir(dir.path())
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "map",
+            "show",
+            "--view",
+            "diagram",
+            "--full",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let full = String::from_utf8(full).unwrap();
+    assert!(full.contains("○ READY"), "{full}");
+    assert!(
+        full.contains("↳ joins a node already shown above"),
+        "{full}"
+    );
+
+    planr()
+        .current_dir(dir.path())
+        .args(["--db", db.to_str().unwrap(), "map", "show", "--full"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--view diagram"));
+
+    let default_json = planr()
+        .current_dir(dir.path())
+        .args(["--db", db.to_str().unwrap(), "--json", "map", "show"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let diagram_json = planr()
+        .current_dir(dir.path())
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--json",
+            "map",
+            "show",
+            "--view",
+            "diagram",
+            "--full",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert_eq!(default_json, diagram_json);
+
+    planr()
+        .args(["map", "show", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("for human supervision only"))
+        .stdout(predicate::str::contains(
+            "agents should use `tree` or `--json`",
+        ));
+    planr()
+        .args(["map", "watch", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Human-only live observer"))
+        .stdout(predicate::str::contains("map show --json"));
+}
+
+#[test]
+fn map_human_edges_distinguish_satisfied_dependencies_without_changing_json() {
+    let dir = tempdir().unwrap();
+    let db = dir.path().join(".planr/planr.sqlite");
+    let db_arg = db.to_str().unwrap();
+    planr()
+        .current_dir(dir.path())
+        .args(["--db", db_arg, "project", "init", "Edge State"])
+        .assert()
+        .success();
+
+    let source = create_test_item(dir.path(), &db, "Source", "source");
+    let target = create_test_item_after(dir.path(), &db, "Target", "target", &source);
+    let conn = Connection::open(&db).unwrap();
+    conn.execute(
+        "UPDATE items SET status = 'closed' WHERE id = ?1",
+        [&source],
+    )
+    .unwrap();
+
+    planr()
+        .current_dir(dir.path())
+        .args(["--db", db_arg, "map", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "blocks✓─▶ · pending {target}"
+        )))
+        .stdout(predicate::str::contains("blocks─▶").not());
+    planr()
+        .current_dir(dir.path())
+        .args(["--db", db_arg, "map", "show", "--view", "diagram"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("└─ then ─▶"))
+        .stdout(predicate::str::contains("└─ blocks ─▶").not());
+    planr()
+        .current_dir(dir.path())
+        .env_remove("NO_COLOR")
+        .env("TERM", "xterm")
+        .env("PLANR_FORCE_COLOR", "1")
+        .args(["--db", db_arg, "map", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b[2mblocks✓─▶\x1b[0m"))
+        .stdout(predicate::str::contains("\x1b[31mblocks✓─▶").not());
+
+    let json = planr()
+        .current_dir(dir.path())
+        .args(["--db", db_arg, "--json", "map", "show"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let json: Value = serde_json::from_slice(&json).unwrap();
+    assert_eq!(json["links"][0]["kind"], "blocks");
+    assert!(!serde_json::to_string(&json).unwrap().contains("blocks✓"));
+    assert!(!serde_json::to_string(&json).unwrap().contains("then"));
+
+    conn.execute(
+        "UPDATE items SET status = 'cancelled' WHERE id = ?1",
+        [&source],
+    )
+    .unwrap();
+    planr()
+        .current_dir(dir.path())
+        .env_remove("NO_COLOR")
+        .env("TERM", "xterm")
+        .env("PLANR_FORCE_COLOR", "1")
+        .args(["--db", db_arg, "map", "show", "--view", "diagram"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("└─ \x1b[31mblocks ─▶\x1b[0m"))
+        .stdout(predicate::str::contains("└─ \x1b[2mthen ─▶").not());
+}
+
+#[test]
+fn map_colors_cover_states_and_all_opt_outs_remain_plain() {
+    let dir = tempdir().unwrap();
+    let db = dir.path().join(".planr/planr.sqlite");
+    let db_arg = db.to_str().unwrap();
+    planr()
+        .current_dir(dir.path())
+        .args(["--db", db_arg, "project", "init", "Color View"])
+        .assert()
+        .success();
+
+    let states = [
+        ("Ready", "ready"),
+        ("Pending", "pending"),
+        ("Picked", "picked"),
+        ("Running", "running"),
+        ("Review", "in_review"),
+        ("Blocked", "blocked"),
+        ("Closed", "closed"),
+        ("Failed", "failed"),
+        ("Cancelled", "cancelled"),
+    ];
+    let items = states
+        .iter()
+        .map(|(title, status)| (create_test_item(dir.path(), &db, title, status), *status))
+        .collect::<Vec<_>>();
+    let conn = Connection::open(&db).unwrap();
+    for (id, status) in items {
+        conn.execute(
+            "UPDATE items SET status = ?1, worker_id = CASE WHEN ?1 IN ('picked','running') THEN 'worker-color' ELSE NULL END WHERE id = ?2",
+            rusqlite::params![status, id],
+        )
+        .unwrap();
+    }
+
+    let forced = planr()
+        .current_dir(dir.path())
+        .env_remove("NO_COLOR")
+        .env("TERM", "xterm")
+        .env("PLANR_FORCE_COLOR", "1")
+        .args(["--db", db_arg, "map", "show"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let forced = String::from_utf8(forced).unwrap();
+    for token in [
+        "\x1b[36m○ ready\x1b[0m",
+        "\x1b[2m· pending\x1b[0m",
+        "\x1b[33m◎ picked\x1b[0m",
+        "\x1b[1;33m◉ running\x1b[0m",
+        "\x1b[35m◇ in_review\x1b[0m",
+        "\x1b[31m⊖ blocked\x1b[0m",
+        "\x1b[32m✓ closed\x1b[0m",
+        "\x1b[1;31m✗ failed\x1b[0m",
+        "\x1b[2m⊘ cancelled\x1b[0m",
+    ] {
+        assert!(forced.contains(token), "missing {token:?} in {forced:?}");
+    }
+
+    let plain = |extra: &[&str], envs: &[(&str, &str)]| {
+        let mut command = planr();
+        command
+            .current_dir(dir.path())
+            .env_remove("NO_COLOR")
+            .env("TERM", "xterm")
+            .env("PLANR_FORCE_COLOR", "1")
+            .args(["--db", db_arg])
+            .args(extra);
+        for (name, value) in envs {
+            command.env(name, value);
+        }
+        command
+            .assert()
+            .success()
+            .stdout(predicate::str::contains("Color View"))
+            .stdout(predicate::str::contains("\x1b[").not());
+    };
+    plain(&["--no-color", "map", "show"], &[]);
+    plain(&["map", "show"], &[("NO_COLOR", "")]);
+    plain(&["map", "show"], &[("TERM", "dumb")]);
+
+    planr()
+        .current_dir(dir.path())
+        .env_remove("NO_COLOR")
+        .env_remove("PLANR_FORCE_COLOR")
+        .env("TERM", "xterm")
+        .args(["--db", db_arg, "map", "show"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("\x1b[").not());
+
+    let json_output = planr()
+        .current_dir(dir.path())
+        .env_remove("NO_COLOR")
+        .env("TERM", "xterm")
+        .env("PLANR_FORCE_COLOR", "1")
+        .args(["--db", db_arg, "--json", "map", "show"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    assert!(!json_output.windows(2).any(|pair| pair == b"\x1b["));
+    serde_json::from_slice::<Value>(&json_output).unwrap();
+}
+
+#[test]
+fn map_watch_observes_an_external_process_change_and_stays_machine_safe() {
+    let dir = tempdir().unwrap();
+    let db = dir.path().join(".planr/planr.sqlite");
+    let db_arg = db.to_str().unwrap().to_string();
+    planr()
+        .current_dir(dir.path())
+        .args(["--db", &db_arg, "project", "init", "Live View"])
+        .assert()
+        .success();
+    let item = create_test_item(dir.path(), &db, "Observed work", "watch me");
+
+    let bin = assert_cmd::cargo::cargo_bin("planr");
+    let mut watcher = StdCommand::new(&bin)
+        .current_dir(dir.path())
+        .env("NO_COLOR", "1")
+        .args([
+            "--db",
+            &db_arg,
+            "map",
+            "watch",
+            "--view",
+            "tree",
+            "--interval-ms",
+            "100",
+            "--iterations",
+            "20",
+            "--no-clear",
+        ])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .unwrap();
+    let stdout = watcher.stdout.take().unwrap();
+    let (ready_tx, ready_rx) = mpsc::channel();
+    let reader = thread::spawn(move || {
+        let mut human = String::new();
+        let mut saw_first_update = false;
+        let mut readiness_sent = false;
+        for line in BufReader::new(stdout).lines() {
+            let line = line.unwrap();
+            saw_first_update |= line.contains("update 1");
+            if saw_first_update && line.contains("○ ready") && !readiness_sent {
+                readiness_sent = true;
+                let _ = ready_tx.send(());
+            }
+            human.push_str(&line);
+            human.push('\n');
+        }
+        human
+    });
+    if let Err(error) = ready_rx.recv_timeout(Duration::from_secs(5)) {
+        let _ = watcher.kill();
+        let _ = watcher.wait();
+        let human = reader.join().unwrap();
+        let mut stderr = String::new();
+        watcher
+            .stderr
+            .take()
+            .unwrap()
+            .read_to_string(&mut stderr)
+            .unwrap();
+        panic!(
+            "watcher did not emit its ready frame: {error}; stdout={human:?}; stderr={stderr:?}"
+        );
+    }
+
+    let pick = planr()
+        .current_dir(dir.path())
+        .env("PLANR_WORKER_ID", "external-agent")
+        .args(["--db", &db_arg, "--json", "pick"])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let pick: Value = serde_json::from_slice(&pick).unwrap();
+    assert_eq!(pick["item"]["id"], item);
+
+    let deadline = Instant::now() + Duration::from_secs(5);
+    let status = loop {
+        match watcher.try_wait().unwrap() {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                let _ = watcher.kill();
+                let status = watcher.wait().unwrap();
+                let human = reader.join().unwrap();
+                let mut stderr = String::new();
+                watcher
+                    .stderr
+                    .take()
+                    .unwrap()
+                    .read_to_string(&mut stderr)
+                    .unwrap();
+                panic!(
+                    "watcher exceeded its deadline ({status}); stdout={human:?}; stderr={stderr:?}"
+                );
+            }
+            None => thread::sleep(Duration::from_millis(10)),
+        }
+    };
+    let human = reader.join().unwrap();
+    let mut stderr = String::new();
+    watcher
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .unwrap();
+    assert!(status.success(), "{stderr}");
+    assert_eq!(human.matches("watching map").count(), 2, "{human}");
+    assert!(human.contains("update 1"), "{human}");
+    assert!(human.contains("update 2"), "{human}");
+    assert!(human.contains("○ ready"), "{human}");
+    assert!(human.contains("◎ picked"), "{human}");
+    assert!(human.contains("external-agent"), "{human}");
+    assert!(!human.contains("\x1b[2J"), "{human:?}");
+
+    planr()
+        .current_dir(dir.path())
+        .env("NO_COLOR", "1")
+        .args([
+            "--db",
+            &db_arg,
+            "map",
+            "watch",
+            "--iterations",
+            "1",
+            "--no-clear",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains(format!(
+            "◎ {item} → Observed work"
+        )))
+        .stdout(predicate::str::contains("PICKED").not())
+        .stdout(predicate::str::contains("worker: external-agent").not());
+
+    planr()
+        .current_dir(dir.path())
+        .env("NO_COLOR", "1")
+        .args([
+            "--db",
+            &db_arg,
+            "map",
+            "watch",
+            "--iterations",
+            "1",
+            "--no-clear",
+            "--full",
+        ])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("◎ PICKED"))
+        .stdout(predicate::str::contains("worker: external-agent"));
+
+    planr()
+        .current_dir(dir.path())
+        .args([
+            "--db",
+            &db_arg,
+            "--json",
+            "map",
+            "watch",
+            "--iterations",
+            "1",
+        ])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("bad_request"))
+        .stdout(predicate::str::contains("/v1/events/stream"));
+    planr()
+        .current_dir(dir.path())
+        .args(["--db", &db_arg, "map", "watch", "--interval-ms", "99"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("invalid value '99'"));
 }
 
 #[test]
@@ -10198,6 +10732,30 @@ fn symmetry_pack_tag_filter_plan_scoped_map_and_audit_next_command() {
     assert_eq!(scoped["total"], 2, "counts must be plan-scoped: {scoped}");
     let unscoped = run(&["map", "show"]);
     assert_eq!(unscoped["items"].as_array().unwrap().len(), 3);
+
+    let output = planr()
+        .current_dir(dir.path())
+        .args([
+            "--db", &db_arg, "map", "show", "--plan", &build_id, "--view", "diagram",
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let scoped_diagram = String::from_utf8(output).unwrap();
+    for item in scoped["items"].as_array().unwrap() {
+        let id = item["id"].as_str().unwrap();
+        assert!(
+            scoped_diagram.contains(id),
+            "scoped diagram omitted {id}: {scoped_diagram}"
+        );
+    }
+    assert!(scoped_diagram.contains("blocks ─▶"), "{scoped_diagram}");
+    assert!(
+        !scoped_diagram.contains("Off-plan chore"),
+        "scoped diagram leaked an off-plan item: {scoped_diagram}"
+    );
     planr()
         .current_dir(dir.path())
         .args([


### PR DESCRIPTION
## Why

- Give human operators a readable, live view of Planr graphs without changing agent-facing or JSON contracts.
- Make state and dependency progress easier to distinguish in terminal output.

## How

- Add condensed and full diagram rendering, accessible state colors, and a change-driven map watcher.
- Render satisfied dependencies as blocks✓ in the tree and neutral then routes in the human diagram while preserving structured blocks links.
- Document the human-only boundary across README, CLI references, and apps/docs, with v1.6.0 release notes.

## Tests

- cargo fmt --check
- cargo clippy --all-targets -- -D warnings
- cargo test (80 unit, 71 E2E, 3 ownership)
- pnpm docs:verify-reference (111 CLI commands, 52 MCP tools, 237 assertions)
- pnpm docs:verify-concepts (15 semantic checks)