### PR TITLE
Fix post-bump pnpm workspace synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 ### Fixed
 
 - Made `scripts/release.sh` the sole writer for version-derived CLI/MCP references during a release: pre-merge references stay aligned with current manifests, while the atomic release commit regenerates, verifies, and stages both after the version bump.
+- Refresh pnpm's derived workspace metadata from the frozen lockfile after the release version bump, fail on any lockfile byte change, and stop before references, gates, or Git mutation when synchronization fails.
 
 ### Security
 

--- a/apps/docs/content/docs/operations/release.mdx
+++ b/apps/docs/content/docs/operations/release.mdx
@@ -19,9 +19,11 @@ Versions must use `x.y.z`, optionally followed by `-alpha.N`, `-beta.N`, or `-rc
 
 <CommandBlock command={'PLANR_RELEASE_EVAL_SUITE=/path/to/planr-evals/suite.json PLANR_RELEASE_EVAL_DB=/path/to/planr-evals/eval.sqlite PLANR_RELEASE_EVAL_RECEIPT=/path/to/planr-evals/receipt.json scripts/release.sh 1.7.2 "one-line release summary"'} label="Release" />
 
-The script synchronizes Cargo, npm, Codex, Claude, Cursor, and `Cargo.lock`
-versions; builds the candidate; regenerates and strictly verifies both generated
-references; validates the receipt against Planr-owned route
+The script synchronizes Cargo, npm, Codex, Claude, and Cursor manifests;
+refreshes pnpm's installed workspace metadata from the frozen lockfile and
+rejects any lockfile byte change; builds the candidate and synchronizes
+`Cargo.lock`; regenerates and strictly verifies both generated references;
+validates the receipt against Planr-owned route
 evidence and the explicitly supplied external suite/database; recomputes and
 gates the stored comparison; runs Rust, deterministic release-gate, package,
 and security checks; then stages the six version files plus both generated

--- a/apps/docs/content/docs/operations/versioning-and-migrations.mdx
+++ b/apps/docs/content/docs/operations/versioning-and-migrations.mdx
@@ -3,7 +3,7 @@ title: Versioning and Migrations
 description: Keep distribution versions aligned and upgrade local Planr data without promising unsafe downgrades.
 ---
 
-The Planr release version is synchronized across `Cargo.toml`, the root npm package, Codex and Claude plugin manifests, the Cursor manifest, and `Cargo.lock` by `scripts/release.sh`. Generated CLI and MCP references follow the currently committed version: release branches keep them at the pre-release manifest version, then the release script regenerates, verifies, and stages both after its atomic version bump. Rust tests, docs CI, the release-script contract test, and the tag workflow reject drift. The private docs package remains independently marked `0.0.0`; its deploy identity should be the Git commit or immutable build artifact, not the Planr binary version.
+The Planr release version is synchronized across `Cargo.toml`, the root npm package, Codex and Claude plugin manifests, the Cursor manifest, and `Cargo.lock` by `scripts/release.sh`. Immediately after the manifest bump, the script refreshes pnpm's derived workspace metadata with `pnpm install --frozen-lockfile` and fails if `pnpm-lock.yaml` changes at all. Generated CLI and MCP references follow the currently committed version: release branches keep them at the pre-release manifest version, then the release script regenerates, verifies, and stages both after its atomic version bump. Rust tests, docs CI, the release-script contract test, and the tag workflow reject drift. The private docs package remains independently marked `0.0.0`; its deploy identity should be the Git commit or immutable build artifact, not the Planr binary version.
 
 ## Dependency policy
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -18,10 +18,12 @@ Published npm versions bundle platform-native binaries; see <https://planr.so/do
 `Cargo.toml`; `package.json`, both plugin manifests under `plugins/planr/`, and
 `.cursor-plugin/plugin.json` must match it. Generated CLI and MCP references
 must match the currently committed version before the release branch merges.
-After bumping and building on clean `main`, the script regenerates and strictly
-checks both references, then stages them in the same atomic release commit as
-the six synchronized version files. Manual tagging or pre-generating a future
-version skips this ownership boundary and can ship stale references.
+After bumping on clean `main`, the script refreshes pnpm's derived workspace
+metadata with the frozen lockfile and rejects any lockfile byte change. It then
+builds, regenerates, and strictly checks both references before staging them in
+the same atomic release commit as the six synchronized version files. Manual
+tagging or pre-generating a future version skips this ownership boundary and
+can ship stale references.
 
 ```bash
 export PLANR_RELEASE_EVAL_SUITE="$HOME/projects/planr-evals/suites/planr-lean-skills-dogfood.suite.json"
@@ -57,11 +59,12 @@ effective-treatment proof.
 The script enforces, in order:
 
 1. branch is `main`, worktree is clean, `CHANGELOG.md` already has a committed `## [x.y.z]` section, and the tag does not exist;
-2. the version is written into all synchronized manifests plus `Cargo.lock`;
-3. the bumped candidate regenerates and strictly verifies both generated references before any later gate or Git mutation;
-4. the candidate binary validates the sanitized receipt, observed effective treatment, candidate binding, and existing Planr comparison/gate before any Git mutation;
-5. deterministic gates: `cargo test` (including manifest drift), `npm pack --dry-run`, and `scripts/security-local.sh` (betterleaks + trivy);
-6. one mechanical commit containing the six version files plus both generated references, an annotated `vx.y.z` tag carrying that summary, and a single push of branch plus tag.
+2. the version is written into all synchronized manifests;
+3. `pnpm install --frozen-lockfile` refreshes installed workspace metadata, and any `pnpm-lock.yaml` byte change stops the release before build, references, gates, or Git mutation;
+4. the build synchronizes `Cargo.lock`, and the bumped candidate regenerates and strictly verifies both generated references before any later gate or Git mutation;
+5. the candidate binary validates the sanitized receipt, observed effective treatment, candidate binding, and existing Planr comparison/gate before any Git mutation;
+6. deterministic gates: `cargo test` (including manifest drift), `npm pack --dry-run`, and `scripts/security-local.sh` (betterleaks + trivy);
+7. one mechanical commit containing the six version files plus both generated references, an annotated `vx.y.z` tag carrying that summary, and a single push of branch plus tag.
 
 Two independent gates back the script:
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -60,6 +60,15 @@ replace plugins/planr/.codex-plugin/plugin.json "s/\"version\": \".*\"/\"version
 replace plugins/planr/.claude-plugin/plugin.json "s/\"version\": \".*\"/\"version\": \"$version\"/"
 replace .cursor-plugin/plugin.json "s/\"version\": \".*\"/\"version\": \"$version\"/"
 
+# pnpm 11 verifies installed workspace metadata before running scripts. Refresh
+# that derived state after the root manifest bump, using only the committed
+# lockfile, and fail closed if synchronization changes a single lockfile byte.
+pnpm install --frozen-lockfile
+if ! git diff --quiet -- pnpm-lock.yaml; then
+  echo "pnpm-lock.yaml changed during frozen workspace synchronization" >&2
+  exit 1
+fi
+
 # Generated references are version-derived release artifacts. Build the bumped
 # binary first, then regenerate and strictly check both references before any
 # release gate or Git mutation. The release commit owns these files together

--- a/scripts/test-release-script.mjs
+++ b/scripts/test-release-script.mjs
@@ -14,6 +14,9 @@ const release = fs.readFileSync(releasePath, "utf8");
 const docsPackage = JSON.parse(fs.readFileSync(path.join(repo, "apps/docs/package.json"), "utf8"));
 const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "planr-release-script-contract-"));
 const version = "9.9.9";
+const workspaceSyncCommand = "pnpm install --frozen-lockfile";
+const lockfileInvariantCommand = "if ! git diff --quiet -- pnpm-lock.yaml; then";
+const referenceGenerateCommand = "pnpm --filter @planr/docs reference:generate";
 const referenceCheckCommand = "pnpm --filter @planr/docs reference:check";
 const laterReleaseCommands = [
   ["local eval receipt gate", "node scripts/verify-release-eval-receipt.mjs"],
@@ -42,6 +45,23 @@ function assertReferenceCheckBeforeEveryLaterCommand(source) {
   }
 }
 
+function assertWorkspaceSyncContract(source) {
+  assert.doesNotMatch(
+    source,
+    /verifyDepsBeforeRun|verify-deps-before-run|verify_deps_before_run/u,
+    "release must never bypass pnpm dependency verification",
+  );
+  const finalBumpIndex = commandIndex(source, "replace .cursor-plugin/plugin.json");
+  const syncIndex = commandIndex(source, workspaceSyncCommand);
+  const invariantIndex = commandIndex(source, lockfileInvariantCommand);
+  const buildIndex = commandIndex(source, "cargo build --quiet");
+  const generateIndex = commandIndex(source, referenceGenerateCommand);
+  assert.ok(finalBumpIndex < syncIndex, "workspace synchronization must follow every manifest bump");
+  assert.ok(syncIndex < invariantIndex, "lockfile byte verification must follow workspace synchronization");
+  assert.ok(invariantIndex < buildIndex, "lockfile byte verification must precede the candidate build");
+  assert.ok(invariantIndex < generateIndex, "lockfile byte verification must precede reference generation");
+}
+
 function commandBlock(source, marker) {
   const markerIndex = commandIndex(source, marker);
   const start = source.lastIndexOf("\n", markerIndex) + 1;
@@ -68,12 +88,12 @@ function write(file, content, mode) {
   if (mode) fs.chmodSync(file, mode);
 }
 
-function setupCase(name) {
+function setupCase(name, releaseSource = release) {
   const root = path.join(tmp, name);
   const bin = path.join(root, "test-bin");
   const commandLog = path.join(root, "commands.log");
   fs.mkdirSync(bin, { recursive: true });
-  write(path.join(root, "scripts/release.sh"), release, 0o755);
+  write(path.join(root, "scripts/release.sh"), releaseSource, 0o755);
   write(path.join(root, "scripts/security-local.sh"), `#!/bin/sh\nset -eu\nprintf '%s\\n' 'security-local' >> "$COMMAND_LOG"\n`, 0o755);
   write(path.join(root, "Cargo.toml"), `[package]\nname = "planr"\nversion = "1.7.1"\n`);
   write(path.join(root, "Cargo.lock"), `[[package]]\nname = "planr"\nversion = "1.7.1"\n`);
@@ -84,6 +104,9 @@ function setupCase(name) {
     ".cursor-plugin/plugin.json",
   ]) write(path.join(root, file), `${JSON.stringify({ name: "planr", version: "1.7.1" }, null, 2)}\n`);
   write(path.join(root, "CHANGELOG.md"), `## [${version}]\n`);
+  write(path.join(root, "pnpm-lock.yaml"), "lockfileVersion: '9.0'\n");
+  write(path.join(root, "pnpm-lock.baseline"), "lockfileVersion: '9.0'\n");
+  write(path.join(root, ".workspace-state-version"), "1.7.1\n");
   write(path.join(root, "apps/docs/content/docs/reference/cli-generated.mdx"), "cli 1.7.1\n");
   write(path.join(root, "apps/docs/content/docs/reference/mcp-schemas-generated.mdx"), "mcp 1.7.1\n");
   write(commandLog, "");
@@ -94,6 +117,10 @@ case "$1 \${2:-}" in
   "rev-parse --abbrev-ref") echo main ;;
   "status --porcelain") ;;
   "rev-parse v${version}") exit 1 ;;
+  "diff --quiet")
+    printf 'git %s\\n' "$*" >> "$COMMAND_LOG"
+    cmp -s pnpm-lock.yaml pnpm-lock.baseline
+    ;;
   *) printf 'git %s\\n' "$*" >> "$COMMAND_LOG" ;;
 esac
 `, 0o755);
@@ -111,7 +138,18 @@ set -eu
 printf 'pnpm %s\\n' "$*" >> "$COMMAND_LOG"
 release_version=$(sed -n 's/.*"version": "\\([^"]*\\)".*/\\1/p' package.json | head -n 1)
 case "$*" in
+  "install --frozen-lockfile")
+    if [ "\${FAIL_WORKSPACE_SYNC:-0}" = 1 ]; then
+      echo 'synthetic workspace sync failure' >&2
+      exit 43
+    fi
+    printf '%s\\n' "$release_version" > .workspace-state-version
+    if [ "\${MUTATE_LOCKFILE_ON_SYNC:-0}" = 1 ]; then
+      printf '%s\\n' '# synthetic drift' >> pnpm-lock.yaml
+    fi
+    ;;
   *"reference:generate")
+    test "$(cat .workspace-state-version)" = "$release_version"
     printf 'cli %s\\n' "$release_version" > apps/docs/content/docs/reference/cli-generated.mdx
     printf 'mcp %s\\n' "$release_version" > apps/docs/content/docs/reference/mcp-schemas-generated.mdx
     ;;
@@ -131,8 +169,8 @@ esac
   return { root, bin, commandLog };
 }
 
-function runCase(name, extraEnv = {}) {
-  const fixture = setupCase(name);
+function runCase(name, extraEnv = {}, releaseSource = release) {
+  const fixture = setupCase(name, releaseSource);
   const result = spawnSync("sh", ["scripts/release.sh", version, "contract test"], {
     cwd: fixture.root,
     encoding: "utf8",
@@ -150,7 +188,7 @@ function runCase(name, extraEnv = {}) {
 }
 
 const buildIndex = release.indexOf("cargo build --quiet");
-const generateIndex = release.indexOf("pnpm --filter @planr/docs reference:generate");
+const generateIndex = release.indexOf(referenceGenerateCommand);
 const checkIndex = release.indexOf("pnpm --filter @planr/docs reference:check");
 const gateIndex = release.indexOf("node scripts/verify-release-eval-receipt.mjs");
 const addIndex = release.indexOf("git add ");
@@ -158,7 +196,24 @@ assert.ok(buildIndex < generateIndex, "reference generation must follow the bump
 assert.ok(generateIndex < checkIndex, "strict reference verification must follow generation");
 assert.ok(checkIndex < gateIndex, "reference verification must precede the local eval gate");
 assert.ok(gateIndex < addIndex, "all release gates must precede Git staging");
+assertWorkspaceSyncContract(release);
 assertReferenceCheckBeforeEveryLaterCommand(release);
+
+const missingSync = release.replace(`${workspaceSyncCommand}\n`, "");
+assert.throws(
+  () => assertWorkspaceSyncContract(missingSync),
+  /release script must contain command line: pnpm install --frozen-lockfile/u,
+  "removing workspace synchronization must fail the release contract before execution",
+);
+const reorderedSync = release.replace(`${workspaceSyncCommand}\n`, "").replace(
+  `${referenceGenerateCommand}\n`,
+  `${referenceGenerateCommand}\n${workspaceSyncCommand}\n`,
+);
+assert.throws(
+  () => assertWorkspaceSyncContract(reorderedSync),
+  /lockfile byte verification must follow workspace synchronization/u,
+  "moving workspace synchronization after reference generation must fail the release contract before execution",
+);
 for (const [label, marker] of laterReleaseCommands) {
   const reordered = moveCommandBeforeReferenceCheck(release, marker);
   assert.ok(
@@ -189,6 +244,19 @@ assert.equal(passing.calls.filter((call) => call.startsWith("git add ")).length,
 assert.ok(passing.calls.includes(expectedAdd), "release must stage the six version files and exactly both generated references");
 const passingCheckIndex = passing.calls.findIndex((call) => call.endsWith("reference:check"));
 assert.ok(passingCheckIndex >= 0, "passing release must execute strict reference verification");
+const passingSyncIndex = passing.calls.indexOf(workspaceSyncCommand);
+const passingInvariantIndex = passing.calls.indexOf("git diff --quiet -- pnpm-lock.yaml");
+const passingBuildIndex = passing.calls.indexOf("cargo build --quiet");
+const passingGenerateIndex = passing.calls.indexOf(referenceGenerateCommand);
+assert.ok(passingSyncIndex >= 0, "passing release must execute frozen workspace synchronization");
+assert.ok(passingSyncIndex < passingInvariantIndex, "workspace synchronization must execute before lockfile verification");
+assert.ok(passingInvariantIndex < passingBuildIndex, "lockfile verification must execute before the candidate build");
+assert.ok(passingBuildIndex < passingGenerateIndex, "candidate build must execute before reference generation");
+assert.equal(
+  fs.readFileSync(path.join(passing.root, "pnpm-lock.yaml"), "utf8"),
+  fs.readFileSync(path.join(passing.root, "pnpm-lock.baseline"), "utf8"),
+  "frozen workspace synchronization must preserve every lockfile byte",
+);
 const laterCallPrefixes = [
   "node scripts/verify-release-eval-receipt.mjs --receipt",
   "cargo test",
@@ -227,14 +295,31 @@ for (const prefix of laterCallPrefixes) {
   assert.ok(!failing.calls.some((call) => call.startsWith(prefix)), `reference failure must stop before ${prefix}`);
 }
 
+const failingSync = runCase("failing-workspace-sync", { FAIL_WORKSPACE_SYNC: "1" });
+assert.equal(failingSync.result.status, 43, "workspace synchronization failure must preserve the pnpm status");
+assert.ok(failingSync.calls.includes(workspaceSyncCommand), "failing workspace synchronization must execute");
+for (const prefix of ["git diff --quiet -- pnpm-lock.yaml", "cargo build --quiet", referenceGenerateCommand, ...laterCallPrefixes]) {
+  assert.ok(!failingSync.calls.some((call) => call.startsWith(prefix)), `workspace sync failure must stop before ${prefix}`);
+}
+
+const driftingSync = runCase("drifting-workspace-sync", { MUTATE_LOCKFILE_ON_SYNC: "1" });
+assert.equal(driftingSync.result.status, 1, "workspace synchronization lockfile drift must fail closed");
+assert.ok(driftingSync.calls.includes(workspaceSyncCommand), "drifting workspace synchronization must execute");
+assert.ok(driftingSync.calls.includes("git diff --quiet -- pnpm-lock.yaml"), "drifting workspace synchronization must verify lockfile bytes");
+for (const prefix of ["cargo build --quiet", referenceGenerateCommand, ...laterCallPrefixes]) {
+  assert.ok(!driftingSync.calls.some((call) => call.startsWith(prefix)), `lockfile drift must stop before ${prefix}`);
+}
+
 fs.rmSync(tmp, { recursive: true, force: true });
 console.log(JSON.stringify({
   verdict: "pass",
   version_transition_owner: "scripts/release.sh",
-  order: ["bump", "build", "generate", "check", "gates", "stage", "commit", "tag", "push"],
+  order: ["bump", "frozen workspace sync", "lockfile byte check", "build", "generate", "check", "gates", "stage", "commit", "tag", "push"],
   staged_version_files: 6,
   staged_generated_references: 2,
   later_commands_guarded: laterReleaseCommands.length,
   seeded_reorder_cases: laterReleaseCommands.length,
+  workspace_sync_adversarial_cases: ["missing", "reordered", "failed", "lockfile drift"],
+  lockfile_byte_invariant: true,
   reference_failure_before_git_mutation: true,
 }, null, 2));


### PR DESCRIPTION
## Why

The stopped 1.7.2 release changed the root package version before invoking a pnpm script. pnpm 11.5.3 correctly rejected the stale installed workspace state because it still recorded version 1.7.1.

## What

- refresh pnpm's derived workspace metadata with `pnpm install --frozen-lockfile` immediately after release manifest bumps
- fail closed if `pnpm-lock.yaml` changes before build or reference generation
- cover positive ordering plus missing, reordered, failed, and lockfile-drifting synchronization
- document the deterministic release contract

No dependency-verification bypass, real release, tag, or publication is included.

## Verification

- `node scripts/test-release-script.mjs`
- `PLANR_TEST_DIR=/Users/kregenrek/projects/planr-test scripts/ci-local.sh`
- complete docs content/type/lint/build/deployment/onboarding/agent/concept/reference/maintenance/release suite
- live Chrome: 68 pages, 20 interactions; Axe: 23 pages, 0 serious/critical
- `scripts/security-local.sh`: BetterLeaks no leaks; Trivy 0 vulnerabilities
- pinned pnpm 11.5.3 frozen synchronization preserved the exact lockfile SHA-256
