### PR TITLE
Release Planr 1.9.0 candidate

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "planr",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Skill-driven planning and execution loop for coding agents: one planr entry point, an autonomous planr-loop, and evidence-backed task graph skills powered by the planr CLI.",
   "author": {
     "name": "instructa",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-07-27
+
+### Added
+
+- Add first-class Pi support through the explicit `planr install pi` and `--client pi` flows, provisioning native `.pi/skills` workflow assets plus optional `pi-subagents` project roles without treating Pi as an MCP host.
+- Add the frozen Pi integration contract, Pi documentation, deterministic inventory checks, observed-client support, generated CLI/MCP references, and E2E coverage for Pi install previews, writes, and project initialization.
+
+### Compatibility
+
+- Keep Pi outside the legacy `--client all` selection so existing Codex, Claude Code, Cursor, and Grok setup remains unchanged. Pi v1 has no MCP or hook contract; `--no-mcp` and `--no-hooks` are accepted for CLI parity without adding extra Pi artifacts.
+
+### Security
+
+- Keep Planr provider-neutral for Pi: generated assets contain no provider credential, model pin, endpoint, Pi auth path, global setting, or session reference. CI verifies deterministic contracts only; authenticated Pi usage remains operator-local.
+
 ## [1.8.0] - 2026-07-27
 
 ### Added
@@ -533,7 +548,8 @@ Initial Planr product release.
 - Tag-driven release pipeline with multi-target builds (darwin/linux, arm64/x86_64) and Homebrew tap automation.
 - Skill workflow documentation for Codex, Claude Code, Cursor, and MCP-only clients.
 
-[Unreleased]: https://github.com/instructa/planr/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/instructa/planr/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/instructa/planr/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/instructa/planr/compare/v1.7.3...v1.8.0
 [1.7.3]: https://github.com/instructa/planr/compare/v1.7.2...v1.7.3
 [1.7.2]: https://github.com/instructa/planr/compare/v1.7.1...v1.7.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -559,7 +559,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "planr"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "planr"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2024"
 license = "MIT"
 description = "Local-first planning and execution coordination for coding agents"

--- a/apps/docs/content/docs/reference/cli-generated.mdx
+++ b/apps/docs/content/docs/reference/cli-generated.mdx
@@ -1,6 +1,6 @@
 ---
 title: Generated CLI Reference
-description: Complete compiled Planr 1.8.0 command and option help, checked against the repository binary.
+description: Complete compiled Planr 1.9.0 command and option help, checked against the repository binary.
 ---
 
 <Callout type="info" title="Generated executable contract">

--- a/apps/docs/content/docs/reference/mcp-schemas-generated.mdx
+++ b/apps/docs/content/docs/reference/mcp-schemas-generated.mdx
@@ -1,6 +1,6 @@
 ---
 title: Generated MCP Tool Schemas
-description: Complete Planr 1.8.0 tools/list inventory with every property, type, description, required field, enum/default declaration, and additionalProperties rule.
+description: Complete Planr 1.9.0 tools/list inventory with every property, type, description, required field, enum/default declaration, and additionalProperties rule.
 ---
 
 <Callout type="info" title="Generated runtime contract">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planr",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Local-first planning and execution coordination for coding agents.",
   "license": "MIT",
   "repository": {

--- a/plugins/planr/.claude-plugin/plugin.json
+++ b/plugins/planr/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planr",
   "description": "Skill-driven planning and execution loop for coding agents: one planr entry point, an autonomous planr-loop, and evidence-backed task graph skills powered by the planr CLI.",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "author": {
     "name": "instructa"
   },

--- a/plugins/planr/.codex-plugin/plugin.json
+++ b/plugins/planr/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "planr",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Skill-driven planning and execution loop for coding agents: one $planr entry point, an autonomous $planr-loop, and evidence-backed task graph skills powered by the planr CLI.",
   "author": {
     "name": "instructa",


### PR DESCRIPTION
## Summary
- prepare the Planr 1.9.0 release candidate from origin/main after the Pi runtime integration merge
- bump Cargo/npm/plugin manifest versions and generated reference descriptions to 1.9.0
- add the dated 1.9.0 changelog section and update compare links

## Local verification
- `git diff --check`
- `sh scripts/verify-changelog-release-links.sh 1.9.0`
- `cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name=="planr") | .version'`
- `node -e 'const fs=require("fs"); const files=["package.json",".cursor-plugin/plugin.json","plugins/planr/.claude-plugin/plugin.json","plugins/planr/.codex-plugin/plugin.json"]; for (const f of files) console.log(f+" "+JSON.parse(fs.readFileSync(f,"utf8")).version); for (const f of ["apps/docs/content/docs/reference/cli-generated.mdx","apps/docs/content/docs/reference/mcp-schemas-generated.mdx"]) console.log(f+" "+fs.readFileSync(f,"utf8").includes("Planr 1.9.0"));'`

Upstream Planr candidate evidence also records `sh scripts/ci-local.sh`, docs, security, packaging, and consumer gates as passed. Conditional external eval receipt remains explicitly absent per recorded evidence; no release tag has been created or pushed.
