### PR TITLE
Prepare Planr 1.10.0-alpha.1

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "planr",
-  "version": "1.10.0",
+  "version": "1.10.0-alpha.1",
   "description": "Skill-driven planning and execution loop for coding agents: one planr entry point, an autonomous planr-loop, and evidence-backed task graph skills powered by the planr CLI.",
   "author": {
     "name": "instructa",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
-## [1.10.0] - 2026-07-30
+## [1.10.0-alpha.1] - 2026-07-31
 
 ### Added
 
@@ -572,8 +572,8 @@ Initial Planr product release.
 - Tag-driven release pipeline with multi-target builds (darwin/linux, arm64/x86_64) and Homebrew tap automation.
 - Skill workflow documentation for Codex, Claude Code, Cursor, and MCP-only clients.
 
-[Unreleased]: https://github.com/instructa/planr/compare/v1.10.0...HEAD
-[1.10.0]: https://github.com/instructa/planr/compare/v1.9.0...v1.10.0
+[Unreleased]: https://github.com/instructa/planr/compare/v1.10.0-alpha.1...HEAD
+[1.10.0-alpha.1]: https://github.com/instructa/planr/compare/v1.9.0...v1.10.0-alpha.1
 [1.9.0]: https://github.com/instructa/planr/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/instructa/planr/compare/v1.7.3...v1.8.0
 [1.7.3]: https://github.com/instructa/planr/compare/v1.7.2...v1.7.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,7 +1054,7 @@ checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "planr"
-version = "1.10.0"
+version = "1.10.0-alpha.1"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "planr"
-version = "1.10.0"
+version = "1.10.0-alpha.1"
 edition = "2024"
 license = "MIT"
 description = "Local-first planning and execution coordination for coding agents"

--- a/apps/docs/content/docs/reference/cli-generated.mdx
+++ b/apps/docs/content/docs/reference/cli-generated.mdx
@@ -1,6 +1,6 @@
 ---
 title: Generated CLI Reference
-description: Complete compiled Planr 1.10.0 command and option help, checked against the repository binary.
+description: Complete compiled Planr 1.10.0-alpha.1 command and option help, checked against the repository binary.
 ---
 
 <Callout type="info" title="Generated executable contract">

--- a/apps/docs/content/docs/reference/mcp-schemas-generated.mdx
+++ b/apps/docs/content/docs/reference/mcp-schemas-generated.mdx
@@ -1,6 +1,6 @@
 ---
 title: Generated MCP Tool Schemas
-description: Complete Planr 1.10.0 tools/list inventory with every property, type, description, required field, enum/default declaration, and additionalProperties rule.
+description: Complete Planr 1.10.0-alpha.1 tools/list inventory with every property, type, description, required field, enum/default declaration, and additionalProperties rule.
 ---
 
 <Callout type="info" title="Generated runtime contract">

--- a/apps/docs/scripts/test-linux-portability-contract.mjs
+++ b/apps/docs/scripts/test-linux-portability-contract.mjs
@@ -11,7 +11,7 @@ const docsRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const repositoryRoot = path.dirname(path.dirname(docsRoot));
 const contract = JSON.parse(await readFile(path.join(repositoryRoot, 'docs', 'contracts', 'LINUX_RELEASE_PORTABILITY.json'), 'utf8'));
 const packageManifest = JSON.parse(await readFile(path.join(repositoryRoot, 'package.json'), 'utf8'));
-const [candidateMajor, candidateMinor, candidatePatch] = packageManifest.version.split('.').map(Number);
+const [candidateMajor, candidateMinor, candidatePatch] = packageManifest.version.split('-')[0].split('.').map(Number);
 const nextCandidatePatch = `${candidateMajor}.${candidateMinor}.${candidatePatch + 1}`;
 const documents = {
   README: await readFile(path.join(repositoryRoot, 'README.md'), 'utf8'),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planr",
-  "version": "1.10.0",
+  "version": "1.10.0-alpha.1",
   "description": "Local-first planning and execution coordination for coding agents.",
   "license": "MIT",
   "repository": {

--- a/plugins/planr/.claude-plugin/plugin.json
+++ b/plugins/planr/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "planr",
   "description": "Skill-driven planning and execution loop for coding agents: one planr entry point, an autonomous planr-loop, and evidence-backed task graph skills powered by the planr CLI.",
-  "version": "1.10.0",
+  "version": "1.10.0-alpha.1",
   "author": {
     "name": "instructa"
   },

--- a/plugins/planr/.codex-plugin/plugin.json
+++ b/plugins/planr/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "planr",
-  "version": "1.10.0",
+  "version": "1.10.0-alpha.1",
   "description": "Skill-driven planning and execution loop for coding agents: one $planr entry point, an autonomous $planr-loop, and evidence-backed task graph skills powered by the planr CLI.",
   "author": {
     "name": "instructa",

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -14662,11 +14662,15 @@ VALUES ('pln-stop-other', 'p-stop-other', 'build', 'other.md', 'Other Stop Plan'
         .stdout(std::process::Stdio::piped())
         .spawn()
         .and_then(|mut child| {
-            child
+            if let Err(error) = child
                 .stdin
                 .as_mut()
                 .unwrap()
-                .write_all(official("thread-stop").as_bytes())?;
+                .write_all(official("thread-stop").as_bytes())
+                && error.kind() != std::io::ErrorKind::BrokenPipe
+            {
+                return Err(error);
+            }
             child.wait_with_output()
         })
         .unwrap();


### PR DESCRIPTION
## Why
- Publish the Evidence system as an opt-in alpha for real-project dogfood.
- Keep npm `latest`, the stable GitHub release, and Homebrew unchanged.

## How
- Synchronize all release manifests to `1.10.0-alpha.1` through the canonical candidate script.
- Regenerate CLI and MCP references.
- Convert the prepared 1.10.0 changelog entry and comparison links to the alpha version.

## Verification
- `scripts/verify-changelog-release-links.sh 1.10.0-alpha.1`
- `npm run verify:release-script`
- `npm run verify:github-actions`
- `pnpm --filter @planr/docs reference:check`