### PR TITLE
fix(eval): preserve legacy suite digest semantics

### DIFF
--- a/src/app/eval_surface.rs
+++ b/src/app/eval_surface.rs
@@ -256,7 +256,11 @@ impl App {
         if !eval_manifest_digest_matches(&digest, &computed_digest, &manifest)? {
             bail!("eval suite digest mismatch: expected {digest}, computed {computed_digest}");
         }
-        let canonical_manifest = canonical_eval_suite_snapshot_value(&manifest, &digest);
+        let canonical_manifest = if computed_digest == digest {
+            canonical_eval_suite_snapshot_value(&manifest, &digest)
+        } else {
+            canonical_legacy_eval_suite_snapshot_value(&manifest, &digest)
+        };
         validate_scorer_control_admission(&canonical_manifest)?;
         let suite_id = string_field(&input, "suite_id")
             .or_else(|| string_field(&canonical_manifest, "suite_id"))
@@ -2348,6 +2352,14 @@ fn sha256_json_digest_without_top_level_digest(value: &Value) -> Result<String> 
 
 fn canonical_eval_suite_snapshot_value(value: &Value, digest: &str) -> Value {
     let mut normalized = normalized_eval_suite_digest_value(value);
+    if let Some(object) = normalized.as_object_mut() {
+        object.insert("digest".to_string(), Value::String(digest.to_string()));
+    }
+    normalized
+}
+
+fn canonical_legacy_eval_suite_snapshot_value(value: &Value, digest: &str) -> Value {
+    let mut normalized = legacy_sorted_json_value(value);
     if let Some(object) = normalized.as_object_mut() {
         object.insert("digest".to_string(), Value::String(digest.to_string()));
     }

--- a/tests/e2e.rs
+++ b/tests/e2e.rs
@@ -8914,6 +8914,96 @@ fn eval_cli_and_mcp_share_one_surface() {
         legacy_suite_digest
     );
 
+    let legacy_supplied_attempt = json!({
+        "id": "legacy-numeric-supplied-attempt",
+        "attempt_index": 0,
+        "terminal_status": "verified_success",
+        "countable": true,
+        "effective_client": "codex",
+        "effective_provider": "openai",
+        "effective_runtime": "codex-cli",
+        "effective_model": "gpt-5.6-terra",
+        "effective_effort": "low",
+        "effective_profile_id": "eval-terra-low",
+        "profile_config_digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+        "runner_harness_version": "supplied-evidence-v1",
+        "route_observation": verified_eval_route_observation(
+            "codex",
+            "gpt-5.6-terra",
+            "low",
+            "eval-terra-low"
+        ),
+        "outcome": {"status": "verified_success"}
+    });
+    let legacy_supplied_sample = json!({
+        "id": "legacy-numeric-supplied-duration",
+        "repetition_index": 0,
+        "warmup": false,
+        "seed": 1,
+        "measure": "duration_ms",
+        "value": 1,
+        "unit": "ms",
+        "source": "process",
+        "metering_basis": "actual_trusted",
+        "basis_source": "process",
+        "basis_confidence": "verified",
+        "attempt": legacy_supplied_attempt
+    });
+    let legacy_supplied_case = json!({
+        "case": {
+            "case_id": "legacy-case",
+            "scorer_id": "score",
+            "scorer_version": "v1",
+            "fixture_digest": legacy_fixture_digest,
+            "status": "pass",
+            "repetition_count": 1,
+            "warmup_count": 0,
+            "assertions": [{"kind": "quality_pass", "status": "pass"}],
+            "command": {"runner": "supplied-evidence"},
+            "reasons": []
+        },
+        "samples": [legacy_supplied_sample]
+    });
+    let legacy_supplied_input = json!({
+        "id": "legacy-numeric-supplied",
+        "suite_digest": legacy_suite_digest.clone(),
+        "subject": {"kind": "local_authenticated_agent", "revision": "legacy-numeric-supplied", "argv": ["maintainer-eval"]},
+        "runner_version": "eval-runner-v1",
+        "planr_version": env!("CARGO_PKG_VERSION"),
+        "testbed_fingerprint": {},
+        "source_state": {"revision": "legacy-numeric-supplied"},
+        "status": "success",
+        "cases": [legacy_supplied_case]
+    });
+    let legacy_supplied_path = dir.path().join("legacy-supplied.json");
+    fs::write(
+        &legacy_supplied_path,
+        serde_json::to_vec_pretty(&legacy_supplied_input).unwrap(),
+    )
+    .unwrap();
+    let legacy_supplied_output = planr()
+        .current_dir(dir.path())
+        .args([
+            "--db",
+            db.to_str().unwrap(),
+            "--json",
+            "eval",
+            "run",
+            "--input",
+            legacy_supplied_path.to_str().unwrap(),
+        ])
+        .assert()
+        .success()
+        .get_output()
+        .stdout
+        .clone();
+    let legacy_supplied_value = single_json_document(&legacy_supplied_output);
+    assert_eval_envelope(&legacy_supplied_value, "eval.run", true);
+    assert_eq!(
+        legacy_supplied_value["object"]["run"]["suite_digest"],
+        legacy_suite_digest
+    );
+
     let runner_fixture = dir.path().join("fixture.json");
     let runner_fixture_bytes = br#"{"fixture":true}"#;
     fs::write(&runner_fixture, runner_fixture_bytes).unwrap();


### PR DESCRIPTION
## Summary
- preserve legacy suite ordering when the declared digest uses the legacy canonicalization
- keep current canonical ordering for current suite digests
- cover supplied-evidence imports in the existing eval CLI/MCP E2E test

## Why
The 1.10.0-alpha.1 release dogfood completed all nine model samples but the candidate rejected the stored run because suite-check reordered a valid legacy-digest manifest before persistence. The later supplied-evidence path then recomputed a different digest.

## Verification
- cargo fmt --check
- cargo test --test e2e eval_cli_and_mcp_share_one_surface -- --exact
- cargo clippy --test e2e -- -D warnings
- external 3x3 release dogfood imported and verified with 9 countable attempts; comparison verdict improved